### PR TITLE
Issue endless loop

### DIFF
--- a/sysbench/sb_options.c
+++ b/sysbench/sb_options.c
@@ -670,7 +670,8 @@ sb_list_t *read_config(FILE *fp, sb_list_t *options)
         if (*tmp == VALUE_SEPARATOR)
           tmp++;
       } else {
-        for (optlen = 0; tmp[optlen] != '\0' && tmp[optlen] != VALUE_SEPARATOR;
+        for (optlen = 0; tmp[optlen] != '\0' && tmp[optlen] != VALUE_SEPARATOR
+                         && !isspace(tmp[optlen]);
              optlen++)
         {
           /* Empty */

--- a/sysbench/sb_options.c
+++ b/sysbench/sb_options.c
@@ -675,9 +675,12 @@ sb_list_t *read_config(FILE *fp, sb_list_t *options)
         {
           /* Empty */
         }
+
         if (tmp[optlen] != '\0')
           tmp[optlen++] = '\0';
+
         add_value(&newopt->values, tmp);
+        tmp += optlen;
       }
     }
   }


### PR DESCRIPTION
These are two fixes to `read_config()` in sb_options.c.
- There's an endless loop, because the `tmp` pointer isn't updated after a value was added to an option
- Reading a value continues until it finds a value separator `,` or reaches end of line. It doesn't stop when it reaches a white space character and includes all trailing white space in the value. This shows up prominently, when the newline is included in the value.