### PR TITLE
Feature config file

### DIFF
--- a/sysbench/sb_options.c
+++ b/sysbench/sb_options.c
@@ -87,6 +87,18 @@ option_t *sb_find_option(const char *name)
   return find_option(&options, name);
 }
 
+static void read_config_file(const char *filename)
+{
+  /* read config options from file */
+  FILE *fp = fopen(filename, "r");
+  if (!fp) {
+    perror(filename);
+  } else {
+    read_config(fp, &options);
+    fclose(fp);
+  }
+}
+
 int set_option(const char *name, const char *value, sb_arg_type_t type)
 {
   option_t *opt;
@@ -119,6 +131,9 @@ int set_option(const char *name, const char *value, sb_arg_type_t type)
       for (tmp = strtok(tmp, ","); tmp != NULL; tmp = strtok(NULL, ","))
         add_value(&opt->values, tmp);
       free(tmp);
+      break;
+    case SB_ARG_TYPE_FILE:
+      read_config_file(value);
       break;
     default:
       printf("Unknown argument type: %d", type);
@@ -162,6 +177,9 @@ void sb_print_options(sb_arg_t *opts)
         break;
       case SB_ARG_TYPE_STRING:
         fmt = "=STRING";
+        break;
+      case SB_ARG_TYPE_FILE:
+        fmt = "=FILENAME";
         break;
       default:
         fmt = "<UNKNOWN>";

--- a/sysbench/sb_options.c
+++ b/sysbench/sb_options.c
@@ -82,7 +82,7 @@ int sb_register_arg_set(sb_arg_t *set)
   return 0;
 }
 
-option_t *sb_find_option(char *name)
+option_t *sb_find_option(const char *name)
 {
   return find_option(&options, name);
 }

--- a/sysbench/sb_options.c
+++ b/sysbench/sb_options.c
@@ -640,6 +640,8 @@ sb_list_t *read_config(FILE *fp, sb_list_t *options)
 
     if ((newopt = add_option(options, buf)) == NULL)
       return NULL;
+
+    free_values(&newopt->values);
     while (*tmp != '\0')
     {
       if (isspace((int)*tmp))

--- a/sysbench/sb_options.h
+++ b/sysbench/sb_options.h
@@ -72,7 +72,7 @@ int sb_register_arg_set(sb_arg_t *set);
 int set_option(const char *name, const char *value, sb_arg_type_t type);
 
 /* Find option specified by 'name' */
-option_t *sb_find_option(char *name);
+option_t *sb_find_option(const char *name);
 
 /* Print list of options specified by 'opts' */
 void sb_print_options(sb_arg_t *opts);

--- a/sysbench/sb_options.h
+++ b/sysbench/sb_options.h
@@ -32,7 +32,8 @@ typedef enum
   SB_ARG_TYPE_SIZE,
   SB_ARG_TYPE_FLOAT,
   SB_ARG_TYPE_STRING,
-  SB_ARG_TYPE_LIST
+  SB_ARG_TYPE_LIST,
+  SB_ARG_TYPE_FILE
 } sb_arg_type_t;
 
 /* Test option definition */

--- a/sysbench/scripting/script_lua.c
+++ b/sysbench/scripting/script_lua.c
@@ -395,6 +395,9 @@ lua_State *sb_lua_new_state(const char *scriptname, int thread_id)
         /*FIXME: should be exported as tables */
         lua_pushnil(state);
         break;
+      case SB_ARG_TYPE_FILE:
+        /* FIXME: no need to export anything */
+        break;
       default:
         log_text(LOG_WARNING, "Global option '%s' will not be exported, because"
                  " the type is unknown", opt->name);

--- a/sysbench/sysbench.c
+++ b/sysbench/sysbench.c
@@ -148,6 +148,7 @@ sb_arg_t general_args[] =
   {"rand-seed", "seed for random number generator, ignored when 0", SB_ARG_TYPE_INT, "0"},
   {"rand-pareto-h", "parameter h for pareto distibution", SB_ARG_TYPE_FLOAT,
    "0.2"},
+  {"config-file", "File containing command line options", SB_ARG_TYPE_FILE, NULL},
   {NULL, NULL, SB_ARG_TYPE_NULL, NULL}
 };
 


### PR DESCRIPTION
This patch implements an additional command line option `--config-file=/path/to/config-file.txt`.
It allows to move options from the command line into a config file. For me, this is especially important when using passwords for MySQL benchmark runs.

I am not entirely sure about the diff in `script_lua.c`. Please review and adjust if necessary.
