### PR TITLE
MS Visual Studio fix

### DIFF
--- a/sysbench/scripting/script_lua.c
+++ b/sysbench/scripting/script_lua.c
@@ -19,6 +19,12 @@
 # include "config.h"
 #endif
 
+#ifdef _GNUC
+#define ATTR_UNUSED __attribute__((unused))
+#else
+#define ATTR_UNUSED
+#endif
+
 #include "script_lua.h"
 #include "lua.h"
 #include "lualib.h"
@@ -234,7 +240,7 @@ int sb_lua_init(void)
   return 0;
 }
 
-sb_request_t sb_lua_get_request(int __attribute__((unused))thread_id)
+sb_request_t sb_lua_get_request(int ATTR_UNUSED thread_id)
 {
   sb_request_t req;
 

--- a/sysbench/tests/cpu/sb_cpu.c
+++ b/sysbench/tests/cpu/sb_cpu.c
@@ -28,6 +28,12 @@
 
 #include "sysbench.h"
 
+#ifdef _GNUC
+#define ATTR_UNUSED __attribute__((unused))
+#else
+#define ATTR_UNUSED
+#endif
+
 /* CPU test arguments */
 static sb_arg_t cpu_args[] =
 {
@@ -97,7 +103,7 @@ int cpu_init(void)
 }
 
 
-sb_request_t cpu_get_request(int __attribute__ ((unused)) thread_id)
+sb_request_t cpu_get_request(int ATTR_UNUSED thread_id)
 {
   sb_request_t req;
   

--- a/sysbench/tests/memory/sb_memory.c
+++ b/sysbench/tests/memory/sb_memory.c
@@ -32,6 +32,12 @@
 # include <sys/shm.h>
 #endif
 
+#ifdef _GNUC
+#define ATTR_UNUSED __attribute__((unused))
+#else
+#define ATTR_UNUSED
+#endif
+
 #define LARGE_PAGE_SIZE (4UL * 1024 * 1024)
 
 /* Memory test arguments */
@@ -216,7 +222,7 @@ int memory_init(void)
 }
 
 
-sb_request_t memory_get_request(int thread_id __attribute__((unused)))
+sb_request_t memory_get_request(int ATTR_UNUSED thread_id)
 {
   sb_request_t      req;
   sb_mem_request_t  *mem_req = &req.u.mem_request;

--- a/sysbench/tests/threads/sb_threads.c
+++ b/sysbench/tests/threads/sb_threads.c
@@ -27,6 +27,12 @@
 # include <pthread.h>
 #endif
 
+#ifdef _GNUC
+#define ATTR_UNUSED __attribute__((unused))
+#else
+#define ATTR_UNUSED
+#endif
+
 #include "sysbench.h"
 
 /* How to test scheduler pthread_yield or sched_yield */
@@ -138,7 +144,7 @@ int threads_cleanup(void)
 }
 
 
-sb_request_t threads_get_request(int thread_id __attribute__((unused)))
+sb_request_t threads_get_request(int ATTR_UNUSED thread_id)
 {
   sb_request_t         sb_req;
   sb_threads_request_t *threads_req = &sb_req.u.threads_request;


### PR DESCRIPTION
Hello,

"__attribute__((unused))" is a GCC directive and it's not working on M$ Visual Studio.

I'm maintening sysbench build for Windows available on my blog. I don't know if it is the good way to fix it, but here is my contribution.

Marc.