### PR TITLE
Fix the issue when threads running < num_threads

### DIFF
--- a/sysbench/sysbench.c
+++ b/sysbench/sysbench.c
@@ -474,6 +474,7 @@ static void *runner_thread(void *arg)
   thread_id = ctxt->id;
 
   log_text(LOG_DEBUG, "Runner thread started (%d)!", thread_id);
+  pthread_mutex_lock(&thread_start_mutex);
   if (test->ops.thread_init != NULL && test->ops.thread_init(thread_id) != 0)
   {
     sb_globals.error = 1;
@@ -484,9 +485,11 @@ static void *runner_thread(void *arg)
     We do this to make sure all threads get to this barrier 
     about the same time 
   */
-  pthread_mutex_lock(&thread_start_mutex);
   sb_globals.num_running++;
   pthread_mutex_unlock(&thread_start_mutex);
+  while(sb_globals.num_running < sb_globals.num_threads) {
+	sleep(1);
+  }
 
   do
   {


### PR DESCRIPTION
I do not know how exactly, but it fixes annoying issue when num_running threads less than num_threads requested.