### PR TITLE
configure.ac: bump version number to 1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([sysbench],[0.9],[akopytov@gmail.com])
+AC_INIT([sysbench],[1.0],[akopytov@gmail.com])
 AC_CONFIG_AUX_DIR([config])
 # Setting CFLAGS here prevents AC_CANONICAL_TARGET from injecting them
 SAVE_CFLAGS=${CFLAGS}


### PR DESCRIPTION
The version number in configure.ac should match the branch.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>