### PR TITLE
%zd for size_t printf ops

### DIFF
--- a/sysbench/tests/memory/sb_memory.c
+++ b/sysbench/tests/memory/sb_memory.c
@@ -415,7 +415,7 @@ void * hugetlb_alloc(size_t size)
   if (shmid < 0)
   {
       log_errno(LOG_FATAL,
-                "Failed to allocate %d bytes from HugeTLB memory.", size);
+                "Failed to allocate %zd bytes from HugeTLB memory.", size);
 
       return NULL;
   }


### PR DESCRIPTION
quick warning fix to use printf of size_t like the man page says.