### PR TITLE
VS2015 fix

### DIFF
--- a/sysbench/sb_win.h
+++ b/sysbench/sb_win.h
@@ -20,8 +20,6 @@
 #define PACKAGE_VERSION "0.5"
 #endif
 
-#define snprintf(buffer, count,  format,...)  \
-  _snprintf_s(buffer,count, _TRUNCATE,format, __VA_ARGS__)
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #define srandom(seed) srand(seed)
@@ -39,11 +37,6 @@ typedef intptr_t ssize_t;
 #endif
 #endif
 
-struct  timespec
-{
-  time_t     tv_sec;
-  long long  tv_nsec;
-};
 typedef HANDLE pthread_t;
 typedef CRITICAL_SECTION pthread_mutex_t;
 


### PR DESCRIPTION
timespec and snprintf are handled natively in VS2015

Project is compiling with VS Community 2015, i think support for VS 2013 should be dropped.