### PR TITLE
Added locking to get_request in lua scripting

### DIFF
--- a/sysbench/scripting/script_lua.c
+++ b/sysbench/scripting/script_lua.c
@@ -241,15 +241,18 @@ sb_request_t sb_lua_get_request(int thread_id)
 
   (void) thread_id; /* unused */
 
+  SB_THREAD_MUTEX_LOCK();
   if (sb_globals.max_requests != 0 && nevents >= sb_globals.max_requests)
   {
     req.type = SB_REQ_TYPE_NULL;
+    SB_THREAD_MUTEX_UNLOCK();
     return req;
   }
 
   req.type = SB_REQ_TYPE_SCRIPT;
   nevents++;
-  
+  SB_THREAD_MUTEX_UNLOCK();
+ 
   return req;
 }
 


### PR DESCRIPTION
I found that, on the lua scripting, there was a race condition that sometimes caused the program to execute more requests than specified by the max-request command line parameter.
This was particularly problematic when preparing a database with parallel_prepare.lua, because if a worker thread is invoked twice in this script, the request to create an existing table is sent twice and that causes "duplicate table" error. Not doing the proper synchronization caused sysbench to send more requests and that caused the problem.