### PR TITLE
Adding volatile modifier to tmp variable in memory test

### DIFF
--- a/sysbench/tests/memory/sb_memory.c
+++ b/sysbench/tests/memory/sb_memory.c
@@ -246,7 +246,7 @@ sb_request_t memory_get_request(int thread_id)
 int memory_execute_request(sb_request_t *sb_req, int thread_id)
 {
   sb_mem_request_t    *mem_req = &sb_req->u.mem_request;
-  int                 tmp = 0;
+  volatile int        tmp = 0;
   int                 idx; 
   int                 *buf, *end;
   log_msg_t           msg;


### PR DESCRIPTION
Issue explanation:

./sysbench/sysbench --test=memory --num-threads=16 \
		    --memory-block-size=268435456 \
		    --memory-total-size=137438953472 \
		    --memory-oper=read \
		    --memory-access-mode=seq \
		    --memory-scope=local run

Without this commit the time to run the above command is 0.0004 seconds.
With this commit the time is greater than 3 seconds.  Essentially,
without the volatile modifier, the compiler optimizes read access so
that no real access happens.