### PR TITLE
0.4 Three additional oltp controls and 1 correction to previous PostgreSQL "FIXME"

### DIFF
--- a/sysbench/tests/oltp/sb_oltp.c
+++ b/sysbench/tests/oltp/sb_oltp.c
@@ -1070,6 +1070,10 @@ sb_request_t get_request_complex(int tid)
   for (i = 0; i < args.delete_inserts; i++)
   {
 
+  range = GET_RANDOM_ID();
+
+  if (!strcmp(driver->sname, "pgsql"))
+  {
   /* FIXME: generate one more UPDATE with the same ID as DELETE/INSERT to make
      PostgreSQL work */
   query = (sb_sql_query_t *)malloc(sizeof(sb_sql_query_t));
@@ -1078,9 +1082,9 @@ sb_request_t get_request_complex(int tid)
   query->num_times = 1;
   query->think_time = get_think_time();
   query->type = SB_SQL_QUERY_UPDATE_INDEX;
-  range = GET_RANDOM_ID();
   query->u.update_query.id = range;
   SB_LIST_ADD_TAIL(&query->listitem, sql_req->queries);
+  }
   
   /* Generate delete */
   query = (sb_sql_query_t *)malloc(sizeof(sb_sql_query_t));


### PR DESCRIPTION
1.  Added oltp-range-selects : Controls whether to include range selects statements or not.

A typical testing practice is to disable all the range select statements, focusing just on point selects.  Previously this required setting four individual controls to zero counts.  Which new control this can be accomplished with a simple oltp-range-selects=off.

2.  Added oltp-delete-inserts : Controls the number of delete/insert pairs to be executed.

Previously there was no control to disable the delete/insert pair on a "write" test.  Now oltp-delete-inserts=0 disables the delete/insert pair.

3.  Added oltp-write-only : Specifies a test to consist of write only statements (insert, update, and deletes).

4.  Converted PostgreSQL "FIXME" to apply only to PostgreSQL

There is a "FIXME" in the file which generates an additional UPDATE with the same ID as DELETE/INSERT pair which appears to have been required just for PostgreSQL.  That statement is now added based on the db-driver.

