### PR TITLE
Added three additional oltp controls (oltp-range-selects, oltp-delete-inserts, oltp-write-only)

### DIFF
--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -132,7 +132,14 @@ function set_vars()
    oltp_distinct_ranges = oltp_distinct_ranges or 1
    oltp_index_updates = oltp_index_updates or 1
    oltp_non_index_updates = oltp_non_index_updates or 1
+   oltp_delete_inserts = oltp_delete_inserts or 1
 
+   if (oltp_range_selets = 'off') then
+   	oltp_range_selects = false
+   else
+   	oltp_range_selects = true
+   end
+   
    if (oltp_auto_inc == 'off') then
       oltp_auto_inc = false
    else

--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -134,12 +134,12 @@ function set_vars()
    oltp_non_index_updates = oltp_non_index_updates or 1
    oltp_delete_inserts = oltp_delete_inserts or 1
 
-   if (oltp_range_selets = 'off') then
-   	oltp_range_selects = false
+   if (oltp_range_selects == 'off') then
+      oltp_range_selects = false
    else
-   	oltp_range_selects = true
+      oltp_range_selects = true
    end
-   
+
    if (oltp_auto_inc == 'off') then
       oltp_auto_inc = false
    else
@@ -150,6 +150,12 @@ function set_vars()
       oltp_read_only = true
    else
       oltp_read_only = false
+   end
+
+   if (oltp_write_only == 'on') then
+      oltp_write_only = true
+   else
+      oltp_write_only = false
    end
 
    if (oltp_skip_trx == 'on') then

--- a/sysbench/tests/db/oltp.lua
+++ b/sysbench/tests/db/oltp.lua
@@ -18,7 +18,6 @@ end
 function event(thread_id)
    local rs
    local i
-   local idx
    local table_name
    local range_start
    local c_val
@@ -30,12 +29,14 @@ function event(thread_id)
       db_query(begin_query)
    end
 
+   if not oltp_write_only then
+
    for i=1, oltp_point_selects do
       rs = db_query("SELECT c FROM ".. table_name .." WHERE id=" .. sb_rand(1, oltp_table_size))
    end
 
    if oltp_range_selects then
-      
+
    for i=1, oltp_simple_ranges do
       range_start = sb_rand(1, oltp_table_size)
       rs = db_query("SELECT c FROM ".. table_name .." WHERE id BETWEEN " .. range_start .. " AND " .. range_start .. "+" .. oltp_range_size - 1)
@@ -58,6 +59,8 @@ function event(thread_id)
 
    end
 
+   end
+   
    if not oltp_read_only then
 
    for i=1, oltp_index_updates do
@@ -73,8 +76,8 @@ function event(thread_id)
       end
    end
 
-   for idx=1, oltp_delete_inserts do
-      
+   for i=1, oltp_delete_inserts do
+
    i = sb_rand(1, oltp_table_size)
 
    rs = db_query("DELETE FROM " .. table_name .. " WHERE id=" .. i)

--- a/sysbench/tests/db/oltp.lua
+++ b/sysbench/tests/db/oltp.lua
@@ -75,7 +75,7 @@ function event(thread_id)
 
    for idx=1, oltp_delete_inserts do
       
-   idx = sb_rand(1, oltp_table_size)
+   i = sb_rand(1, oltp_table_size)
 
    rs = db_query("DELETE FROM " .. table_name .. " WHERE id=" .. i)
    

--- a/sysbench/tests/db/oltp.lua
+++ b/sysbench/tests/db/oltp.lua
@@ -18,6 +18,7 @@ end
 function event(thread_id)
    local rs
    local i
+   local idx
    local table_name
    local range_start
    local c_val
@@ -33,6 +34,8 @@ function event(thread_id)
       rs = db_query("SELECT c FROM ".. table_name .." WHERE id=" .. sb_rand(1, oltp_table_size))
    end
 
+   if oltp_range_selects then
+      
    for i=1, oltp_simple_ranges do
       range_start = sb_rand(1, oltp_table_size)
       rs = db_query("SELECT c FROM ".. table_name .." WHERE id BETWEEN " .. range_start .. " AND " .. range_start .. "+" .. oltp_range_size - 1)
@@ -53,6 +56,8 @@ function event(thread_id)
       rs = db_query("SELECT DISTINCT c FROM ".. table_name .." WHERE id BETWEEN " .. range_start .. " AND " .. range_start .. "+" .. oltp_range_size - 1 .. " ORDER BY c")
    end
 
+   end
+
    if not oltp_read_only then
 
    for i=1, oltp_index_updates do
@@ -68,7 +73,9 @@ function event(thread_id)
       end
    end
 
-   i = sb_rand(1, oltp_table_size)
+   for idx=1, oltp_delete_inserts do
+      
+   idx = sb_rand(1, oltp_table_size)
 
    rs = db_query("DELETE FROM " .. table_name .. " WHERE id=" .. i)
    
@@ -78,6 +85,8 @@ function event(thread_id)
 ###########-###########-###########-###########-###########]])
 
    rs = db_query("INSERT INTO " .. table_name ..  " (id, k, c, pad) VALUES " .. string.format("(%d, %d, '%s', '%s')",i, sb_rand(1, oltp_table_size) , c_val, pad_val))
+
+   end
 
    end -- oltp_read_only
 


### PR DESCRIPTION
Added three additional oltp controls (oltp-range-selects, oltp-delete-inserts, oltp-write-only)

1.  oltp-range-selects : Controls whether to include range selects statements or not.

A typical testing practice is to disable all the range select statements, focusing just on point selects.  Previously this required setting four individual controls to zero counts.  Which new control this can be accomplished with a simple oltp-range-selects=off.

2.  oltp-delete-inserts : Controls the number of delete/insert pairs to be executed.

Previously there was no control to disable the delete/insert pair on a "write" test.  Now oltp-delete-inserts=0 disables the delete/insert pair.

3.  oltp-write-only : Specifies a test to consist of write only statements (insert, update, and deletes).

