### PR TITLE
Fix write issue with NFS direct I/O

### DIFF
--- a/sysbench/tests/fileio/sb_fileio.c
+++ b/sysbench/tests/fileio/sb_fileio.c
@@ -1934,6 +1934,12 @@ int parse_arguments(void)
   for (i = 0; i < sb_globals.num_threads; i++)
   {
     per_thread[i].buffer = sb_memalign(file_max_request_size);
+    if (per_thread[i].buffer == NULL)
+    {
+      log_text(LOG_FATAL, "Failed to allocate a memory buffer");
+      return 1;
+    }
+    memset(per_thread[i].buffer, 0, file_max_request_size);
   }
 
   return 0;


### PR DESCRIPTION
Hello Alexey,

I saw small rpc request size (i.e., 4KB) when I wrote 128KB block to NFS mount path with direct io option. Normally, the rpc request size should be 128KB. After analyzing the issue, I knew that the Linux kernel using in CentOS7, Ubuntu 14.04, etc. did not coalesce the multiple 4KB rpc requests into one 128KB rpc request when the memory buffer was not filled with anything. As you know, the malloc function uses mmap with MAP_PRIVATE option which means to create a private copy-on-write mapping. Because of the copy-on-write mapping, NFS kerenel function (fs/nfs/pagelist.c, nfs_can_coalesce_requests) cannot coalesce rpc requests. By the way, there is no problem when I use validate option because the buffer is filled with random values. Here is how to reproduce.

In the NFS server,
  1. Install NFS server.

In the NFS client,
  1. Mount it
      ex. 
      # mount -o tcp,vers=3,nolock x.x.x.x:/xxx /mnt
  2. Run SysBench.
      ex. 
      # sysbench --test=fileio --file-total-size=16G --file-num=16 prepare
      # sysbench --test=fileio --file-total-size=16G --file-test-mode=rndwr --max-time=180 --max-requests=0 --num-threads=16 --file-num=16 --file-block-size=128K --file-io-mode=sync --file-extra-flags=direct --file-fsync-freq=0 run
  3. Check kB/op
      # nfsiostat 1