### PR TITLE
1.0

### DIFF
--- a/sysbench/drivers/pgsql/drv_pgsql.c
+++ b/sysbench/drivers/pgsql/drv_pgsql.c
@@ -519,7 +519,7 @@ int pgsql_drv_execute(db_stmt_t *stmt, db_result_set_t *rs)
     /* Convert SysBench bind structures to PgSQL data */
     for (i = 0; i < (unsigned)pgstmt->nparams; i++)
     {
-      if (stmt->bound_param[i].is_null)
+      if (stmt->bound_param[i].is_null && *(stmt->bound_param[i].is_null))
         continue;
 
       switch (stmt->bound_param[i].type) {


### PR DESCRIPTION
Prepared statements don't work with PostgreSQL. I got following error.

> PQexecPrepared() failed: 7 ERROR:  invalid input syntax for integer ""

This pull request intended to fix that.