### PR TITLE
pkgdatadir for lua files

### DIFF
--- a/sysbench/scripting/Makefile.am
+++ b/sysbench/scripting/Makefile.am
@@ -18,7 +18,7 @@
 if USE_LUA
 SUBDIRS = lua .
 lua_sources = script_lua.c script_lua.h
-AM_CPPFLAGS += -I$(srcdir)/lua/src
+AM_CPPFLAGS += -I$(srcdir)/lua/src -DDATA_PATH=\"$(pkgdatadir)\"
 endif
 
 noinst_LIBRARIES = libsbscript.a

--- a/sysbench/scripting/script_lua.c
+++ b/sysbench/scripting/script_lua.c
@@ -29,6 +29,8 @@
 
 #include "db_driver.h"
 
+#include <stdlib.h>
+
 #define EVENT_FUNC "event"
 #define PREPARE_FUNC "prepare"
 #define CLEANUP_FUNC "cleanup"
@@ -168,6 +170,8 @@ unsigned int sb_lua_table_size(lua_State *, int);
 int script_load_lua(const char *testname, sb_test_t *test)
 {
   unsigned int i;
+
+  setenv("LUA_PATH", DATA_PATH LUA_DIRSEP "?.lua", 0);
 
   /* Initialize global interpreter state */
   gstate = sb_lua_new_state(testname, -1);
@@ -488,8 +492,27 @@ lua_State *sb_lua_new_state(const char *scriptname, int thread_id)
   luaL_newmetatable(state, "sysbench.stmt");
 
   luaL_newmetatable(state, "sysbench.rs");
-  
-  if (luaL_loadfile(state, scriptname) || lua_pcall(state, 0, 0, 0))
+
+  if (luaL_loadfile(state, scriptname))
+  {
+    /* first location failed - look in DATA_PATH */
+    char p[PATH_MAX + 1];
+    strncpy(p, DATA_PATH LUA_DIRSEP, sizeof(p));
+    strncat(p, scriptname, sizeof(p));
+    if (!strrchr(scriptname, '.'))
+    {
+      /* add .lua extension if there isn't one */
+      strncat(p, ".lua", sizeof(p));
+    }
+
+    if (luaL_loadfile(state, p))
+    {
+      lua_error(state);
+      return NULL;
+    }
+  }
+
+  if (lua_pcall(state, 0, 0, 0))
   {
     lua_error(state);
     return NULL;

--- a/sysbench/tests/db/Makefile.am
+++ b/sysbench/tests/db/Makefile.am
@@ -15,7 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-EXTRA_DIST = delete.lua insert.lua oltp.lua \
+dist_pkgdata_DATA = common.lua delete.lua insert.lua bulk_insert.lua \
+             oltp.lua \
              oltp_simple.lua \
              parallel_prepare.lua \
              select_random_points.lua \

--- a/sysbench/tests/db/delete.lua
+++ b/sysbench/tests/db/delete.lua
@@ -1,6 +1,10 @@
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()

--- a/sysbench/tests/db/insert.lua
+++ b/sysbench/tests/db/insert.lua
@@ -1,6 +1,10 @@
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()

--- a/sysbench/tests/db/oltp.lua
+++ b/sysbench/tests/db/oltp.lua
@@ -1,6 +1,10 @@
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()

--- a/sysbench/tests/db/oltp_simple.lua
+++ b/sysbench/tests/db/oltp_simple.lua
@@ -1,6 +1,10 @@
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()

--- a/sysbench/tests/db/parallel_prepare.lua
+++ b/sysbench/tests/db/parallel_prepare.lua
@@ -1,8 +1,12 @@
 -- for proper initialization use --max-requests = N, where N is --num-threads
 --
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()

--- a/sysbench/tests/db/select.lua
+++ b/sysbench/tests/db/select.lua
@@ -1,6 +1,10 @@
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()

--- a/sysbench/tests/db/update_index.lua
+++ b/sysbench/tests/db/update_index.lua
@@ -1,6 +1,10 @@
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()

--- a/sysbench/tests/db/update_non_index.lua
+++ b/sysbench/tests/db/update_non_index.lua
@@ -1,6 +1,10 @@
-pathtest = string.match(test, "(.*/)") or ""
+pathtest = string.match(test, "(.*/)")
 
-dofile(pathtest .. "common.lua")
+if pathtest then
+   dofile(pathtest .. "common.lua")
+else
+   require("common")
+end
 
 function thread_init(thread_id)
    set_vars()


### PR DESCRIPTION
A couple of changes here to make it easier for those who package/hand install sysbench.

The lua files are now installed to pkgdatadir as set by autoconf (/usr/local/share/sysbench).

Code to load from this directory is also included so --test=oltp will load it from there.

The setenv of LUA_PATH is a kludge. Setting the path like setpath (./sysbench/scripting/lua/src/loadlib.c) or changeing package.path like http://stackoverflow.com/questions/4125971/setting-the-global-lua-path-variable-from-c-c/4127429#4127429 is probably the right way. I wanted to see if you where generally happy with the concept and see if this breaks self tests or anything else before too much was done.