### PR TITLE
error out when negative values are passed as parameters

### DIFF
--- a/sysbench/sysbench.c
+++ b/sysbench/sysbench.c
@@ -1017,7 +1017,7 @@ static int init(void)
   long              res;
 
   sb_globals.num_threads = sb_get_value_int("num-threads");
-  if (sb_globals.num_threads == 0)
+  if (sb_globals.num_threads <= 0)
   {
     log_text(LOG_FATAL, "Invalid value for --num-threads: %d.\n", sb_globals.num_threads);
     return 1;

--- a/sysbench/tests/fileio/sb_fileio.c
+++ b/sysbench/tests/fileio/sb_fileio.c
@@ -1778,7 +1778,7 @@ int parse_arguments(void)
   
   num_files = sb_get_value_int("file-num");
 
-  if (num_files == 0)
+  if (num_files <= 0)
   {
     log_text(LOG_FATAL, "Invalid value for file-num: %d", num_files);
     return 1;


### PR DESCRIPTION
Error out when negative values are passed as `num_threads` and `num_files`:

Those parameters are not meant to be negative:
* passing `num_threads=1` crashes with "Memory allocation failure."
* while `num_files=-1` is interpreted as unsigned int making it create
  lots(2^31-1) of files