### PR TITLE
Add a way to skip DELETE(id) + INSERT(id) block via a new oltp_auto_inc_read_only variable

### DIFF
--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -148,10 +148,10 @@ function set_vars()
       oltp_auto_inc = true
    end
 
-   if (oltp_auto_inc_read_only == 'off') then
-      oltp_auto_inc_read_only = false
-   else
+   if (oltp_auto_inc_read_only == 'on') then
       oltp_auto_inc_read_only = true
+   else
+      oltp_auto_inc_read_only = false
    end
 
    if (oltp_read_only == 'on') then

--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -148,6 +148,12 @@ function set_vars()
       oltp_auto_inc = true
    end
 
+   if (oltp_auto_inc_read_only == 'off') then
+      oltp_auto_inc_read_only = false
+   else
+      oltp_auto_inc_read_only = true
+   end
+
    if (oltp_read_only == 'on') then
       oltp_read_only = true
    else

--- a/sysbench/tests/db/oltp.lua
+++ b/sysbench/tests/db/oltp.lua
@@ -89,6 +89,8 @@ function event(thread_id)
       end
    end
 
+   if not oltp_auto_inc_read_only then
+
    for i=1, oltp_delete_inserts do
 
    i = sb_rand(1, oltp_table_size)
@@ -101,6 +103,8 @@ function event(thread_id)
 ###########-###########-###########-###########-###########]])
 
    rs = db_query("INSERT INTO " .. table_name ..  " (id, k, c, pad) VALUES " .. string.format("(%d, %d, '%s', '%s')",i, sb_rand(1, oltp_table_size) , c_val, pad_val))
+
+   end
 
    end
 


### PR DESCRIPTION
Create a new variable oltp_auto_inc_read_only (default false) that allows us to skip the DELETE (id) + INSERT (id) block, for DB engines that don't allow inserting rows where the AUTO-INCREMENT variable has a user-specified value.

This was tested using --with-pgsql engine with a sample TRIGGER such as the one given below (executed between the prepare & run phase), to check whether the system attempts a DELETE / INSERT operation when the flag is on.

```
CREATE OR REPLACE FUNCTION tempdel()
  RETURNS trigger AS
$BODY$
BEGIN
 IF TG_OP = 'INSERT' THEN
    IF NEW.id IS NOT NULL THEN
      RAISE EXCEPTION 'Insert values not allowed';
      RETURN NULL;
    END IF;
 END IF;
 
 IF TG_OP = 'UPDATE' THEN
    IF OLD.id <> NEW.id THEN
      RAISE EXCEPTION 'Update ID not allowed';
      RETURN NULL;
    END IF;
 END IF;
 
 RETURN NEW;
END;
$BODY$ LANGUAGE PLPGSQL;

CREATE TRIGGER sbtest1_trg BEFORE INSERT OR UPDATE ON sbtest1
    FOR EACH ROW EXECUTE PROCEDURE tempdel();
    
```