### PR TITLE
Draft: This is a working patch (hard-wired though) that works with Redshift

### DIFF
--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -148,10 +148,10 @@ function set_vars()
       oltp_auto_inc = true
    end
 
-   if (oltp_auto_inc_read_only == 'off') then
-      oltp_auto_inc_read_only = false
-   else
+   if (oltp_auto_inc_read_only == 'on') then
       oltp_auto_inc_read_only = true
+   else
+      oltp_auto_inc_read_only = false
    end
 
    if (oltp_read_only == 'on') then

--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -148,6 +148,12 @@ function set_vars()
       oltp_auto_inc = true
    end
 
+   if (oltp_auto_inc_read_only == 'off') then
+      oltp_auto_inc_read_only = false
+   else
+      oltp_auto_inc_read_only = true
+   end
+
    if (oltp_read_only == 'on') then
       oltp_read_only = true
    else

--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -17,6 +17,12 @@ function create_insert(table_id)
      index_name = "PRIMARY KEY"
    end
 
+   if enable_pgsql_redshift_only then
+     auto_inc_type = "INTEGER IDENTITY(1,1)"
+   else
+     auto_inc_type = "SERIAL"
+   end
+
    i = table_id
 
    print("Creating table 'sbtest" .. i .. "'...")
@@ -36,7 +42,7 @@ pad CHAR(60) DEFAULT '' NOT NULL,
    elseif (db_driver == "pgsql") then
       query = [[
 CREATE TABLE sbtest]] .. i .. [[ (
-id SERIAL NOT NULL,
+id ]] .. auto_inc_type .. [[ NOT NULL,
 k INTEGER DEFAULT '0' NOT NULL,
 c CHAR(120) DEFAULT '' NOT NULL,
 pad CHAR(60) DEFAULT '' NOT NULL,
@@ -146,6 +152,16 @@ function set_vars()
       oltp_auto_inc = false
    else
       oltp_auto_inc = true
+   end
+
+enable_pgsql_redshift_only='on'
+
+   if ((db_driver == "pgsql") and (enable_pgsql_redshift_only == 'on')) then
+      enable_pgsql_redshift_only = true
+      oltp_create_secondary = 'off'
+      oltp_auto_inc_read_only = 'on'
+   else
+      enable_pgsql_redshift_only = false
    end
 
    if (oltp_auto_inc_read_only == 'on') then

--- a/sysbench/tests/db/oltp.lua
+++ b/sysbench/tests/db/oltp.lua
@@ -89,6 +89,8 @@ function event(thread_id)
       end
    end
 
+   if not oltp_auto_inc_read_only then
+
    for i=1, oltp_delete_inserts do
 
    i = sb_rand(1, oltp_table_size)
@@ -101,6 +103,8 @@ function event(thread_id)
 ###########-###########-###########-###########-###########]])
 
    rs = db_query("INSERT INTO " .. table_name ..  " (id, k, c, pad) VALUES " .. string.format("(%d, %d, '%s', '%s')",i, sb_rand(1, oltp_table_size) , c_val, pad_val))
+
+   end
 
    end
 


### PR DESCRIPTION
This is a working patch that runs the Postgres test on a Redshift cluster. It takes care of missing features / limitations with Redshift, and although I am not sure what the numbers mean, as a first draft this runs successfully.

What I need help with / am failing at, is to be able to pass something like --with-pgsql=redshift on the command line onto the lua script that allows me to *not* hard-wire enable_pgsql_redshift_only (as it currently is at line 157, which obviously means that currently this patch breaks postgres support).

Ideally, what I had in mind was that --with-pgsql works with native postgres engine (as it currently does) but different postgres derivatives get supported like this --with-pgsql=redshift or --with-pgsql=greenplum etc... Again, obviously open to more ideas.