### PR TITLE
Add AWS Redshift support for sysbench

### DIFF
--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -17,11 +17,11 @@ function create_insert(table_id)
      index_name = "PRIMARY KEY"
    end
 
---   if (with_pgsql == 'redshift') then
+   if (with_pgsql == 'redshift') then
       auto_inc_type = "INTEGER IDENTITY(1,1)"
-  -- else
-    --  auto_inc_type = "SERIAL"
-  -- end
+   else
+      auto_inc_type = "SERIAL"
+   end
 
    i = table_id
 
@@ -93,10 +93,10 @@ pad CHAR(60) DEFAULT '' NOT NULL,
 
    db_bulk_insert_done()
 
---   if oltp_create_secondary then
-  --   print("Creating secondary indexes on 'sbtest" .. i .. "'...")
-    -- db_query("CREATE INDEX k_" .. i .. " on sbtest" .. i .. "(k)")
-  -- end
+   if oltp_create_secondary then
+     print("Creating secondary indexes on 'sbtest" .. i .. "'...")
+     db_query("CREATE INDEX k_" .. i .. " on sbtest" .. i .. "(k)")
+   end
 
 end
 

--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -17,6 +17,14 @@ function create_insert(table_id)
      index_name = "PRIMARY KEY"
    end
 
+   if (with_pgsql == 'redshift') then
+      auto_inc_type = "INTEGER IDENTITY(1,1)"
+   else
+      auto_inc_type = "SERIAL"
+   end
+print ("value of db-driver" .. db_driver)
+--print ("Value of with_pgsql" .. with_pgsql)
+
    i = table_id
 
    print("Creating table 'sbtest" .. i .. "'...")
@@ -36,7 +44,7 @@ pad CHAR(60) DEFAULT '' NOT NULL,
    elseif (db_driver == "pgsql") then
       query = [[
 CREATE TABLE sbtest]] .. i .. [[ (
-id SERIAL NOT NULL,
+id ]] .. auto_inc_type .. [[ NOT NULL,
 k INTEGER DEFAULT '0' NOT NULL,
 c CHAR(120) DEFAULT '' NOT NULL,
 pad CHAR(60) DEFAULT '' NOT NULL,
@@ -146,6 +154,10 @@ function set_vars()
       oltp_auto_inc = false
    else
       oltp_auto_inc = true
+   end
+
+   if (with_pgsql == 'redshift') then
+      oltp_create_secondary = 'off'
    end
 
    if (oltp_read_only == 'on') then

--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -17,13 +17,11 @@ function create_insert(table_id)
      index_name = "PRIMARY KEY"
    end
 
-   if (with_pgsql == 'redshift') then
+--   if (with_pgsql == 'redshift') then
       auto_inc_type = "INTEGER IDENTITY(1,1)"
-   else
-      auto_inc_type = "SERIAL"
-   end
-print ("value of db-driver" .. db_driver)
---print ("Value of with_pgsql" .. with_pgsql)
+  -- else
+    --  auto_inc_type = "SERIAL"
+  -- end
 
    i = table_id
 
@@ -95,10 +93,10 @@ pad CHAR(60) DEFAULT '' NOT NULL,
 
    db_bulk_insert_done()
 
-   if oltp_create_secondary then
-     print("Creating secondary indexes on 'sbtest" .. i .. "'...")
-     db_query("CREATE INDEX k_" .. i .. " on sbtest" .. i .. "(k)")
-   end
+--   if oltp_create_secondary then
+  --   print("Creating secondary indexes on 'sbtest" .. i .. "'...")
+    -- db_query("CREATE INDEX k_" .. i .. " on sbtest" .. i .. "(k)")
+  -- end
 
 end
 
@@ -156,10 +154,6 @@ function set_vars()
       oltp_auto_inc = true
    end
 
-   if (with_pgsql == 'redshift') then
-      oltp_create_secondary = 'off'
-   end
-
    if (oltp_read_only == 'on') then
       oltp_read_only = true
    else
@@ -186,6 +180,11 @@ function set_vars()
       oltp_create_secondary = false
    else
       oltp_create_secondary = true
+   end
+
+   if (with_pgsql == 'redshift') then
+      oltp_create_secondary = false
+      oltp_delete_inserts = 0
    end
 
 end

--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -17,7 +17,7 @@ function create_insert(table_id)
      index_name = "PRIMARY KEY"
    end
 
-   if (with_pgsql == 'redshift') then
+   if (pgsql_variant == 'redshift') then
       auto_inc_type = "INTEGER IDENTITY(1,1)"
    else
       auto_inc_type = "SERIAL"
@@ -182,7 +182,7 @@ function set_vars()
       oltp_create_secondary = true
    end
 
-   if (with_pgsql == 'redshift') then
+   if (pgsql_variant == 'redshift') then
       oltp_create_secondary = false
       oltp_delete_inserts = 0
    end

--- a/sysbench/tests/db/select_random_points.lua
+++ b/sysbench/tests/db/select_random_points.lua
@@ -36,16 +36,9 @@ function prepare()
     
 
    elseif (db_driver == "pgsql") then
-
-      if (pgsql_variant == 'redshift') then
-         auto_inc_type = "INTEGER " .. (oltp_auto_inc and "IDENTITY(1,1)")
-      else
-         auto_inc_type = ((oltp_auto_inc and "SERIAL") or "INTEGER")
-      end
-
       query = [[
         CREATE TABLE sbtest (
-          id ]] .. auto_inc_type .. [[,
+          id ]] .. ((oltp_auto_inc and "SERIAL") or "") .. [[,
           k INTEGER DEFAULT '0' NOT NULL,
           c CHAR(120) DEFAULT '' NOT NULL,
           pad CHAR(60) DEFAULT '' NOT NULL, 
@@ -75,9 +68,7 @@ function prepare()
                  FOR EACH ROW BEGIN SELECT sbtest_seq.nextval INTO :new.id FROM DUAL; END;]])
    end
 
-   if oltp_create_secondary then
-      db_query("CREATE INDEX k on sbtest(k)")
-   end
+   db_query("CREATE INDEX k on sbtest(k)")
 
    print("Inserting " .. oltp_table_size .. " records into 'sbtest'")
    

--- a/sysbench/tests/db/select_random_points.lua
+++ b/sysbench/tests/db/select_random_points.lua
@@ -38,7 +38,7 @@ function prepare()
    elseif (db_driver == "pgsql") then
       query = [[
         CREATE TABLE sbtest (
-          id ]] .. (sb.oltp_auto_inc and "SERIAL") or "" .. [[,
+          id ]] .. ((oltp_auto_inc and "SERIAL") or "") .. [[,
           k INTEGER DEFAULT '0' NOT NULL,
           c CHAR(120) DEFAULT '' NOT NULL,
           pad CHAR(60) DEFAULT '' NOT NULL, 

--- a/sysbench/tests/db/select_random_ranges.lua
+++ b/sysbench/tests/db/select_random_ranges.lua
@@ -68,9 +68,7 @@ function prepare()
                  FOR EACH ROW BEGIN SELECT sbtest_seq.nextval INTO :new.id FROM DUAL; END;]])
    end
 
-   if oltp_create_secondary then
-      db_query("CREATE INDEX k on sbtest(k)")
-   end
+   db_query("CREATE INDEX k on sbtest(k)")
 
    print("Inserting " .. oltp_table_size .. " records into 'sbtest'")
    

--- a/sysbench/tests/db/select_random_ranges.lua
+++ b/sysbench/tests/db/select_random_ranges.lua
@@ -68,7 +68,9 @@ function prepare()
                  FOR EACH ROW BEGIN SELECT sbtest_seq.nextval INTO :new.id FROM DUAL; END;]])
    end
 
-   db_query("CREATE INDEX k on sbtest(k)")
+   if oltp_create_secondary then
+      db_query("CREATE INDEX k on sbtest(k)")
+   end
 
    print("Inserting " .. oltp_table_size .. " records into 'sbtest'")
    

--- a/sysbench/tests/db/select_random_ranges.lua
+++ b/sysbench/tests/db/select_random_ranges.lua
@@ -38,7 +38,7 @@ function prepare()
    elseif (db_driver == "pgsql") then
       query = [[
         CREATE TABLE sbtest (
-          id ]] .. (sb.oltp_auto_inc and "SERIAL") or "" .. [[,
+          id ]] .. ((oltp_auto_inc and "SERIAL") or "") .. [[,
           k INTEGER DEFAULT '0' NOT NULL,
           c CHAR(120) DEFAULT '' NOT NULL,
           pad CHAR(60) DEFAULT '' NOT NULL, 

--- a/tests/t/drv_pgsql_redshift.t
+++ b/tests/t/drv_pgsql_redshift.t
@@ -1,0 +1,47 @@
+########################################################################
+Redshift driver tests
+########################################################################
+
+  $ if [ -z "${SBTEST_PGSQL_ARGS:-}" ]
+  > then
+  >   exit 80
+  > fi
+  $ DB_DRIVER_ARGS="--db-driver=pgsql --pgsql-variant=redshift $SBTEST_PGSQL_ARGS"
+  $ . $SBTEST_INCDIR/drv_common.sh
+  sysbench *.*:  multi-threaded system evaluation benchmark (glob)
+  
+  Running the test with following options:
+  Number of threads: 2
+  Initializing random number generator from current time
+  
+  
+  Initializing worker threads...
+  
+  Threads started!
+  
+  OLTP test statistics:
+      queries performed:
+          read:                            10
+          write:                           0
+          other:                           0
+          total:                           10
+      transactions:                        0      (0.00 per sec.)
+      read/write requests:                 10     (*.* per sec.) (glob)
+      other operations:                    0      (0.00 per sec.)
+      ignored errors:                      0      (0.00 per sec.)
+      reconnects:                          0      (0.00 per sec.)
+  
+  General statistics:
+      total time:                          *.*s (glob)
+      total number of events:              10
+      total time taken by event execution: *.*s (glob)
+      response time:
+           min:                                 *.*ms (glob)
+           avg:                                 *.*ms (glob)
+           max:                                 *.*ms (glob)
+           approx.  95 percentile:              *.*ms (glob)
+  
+  Threads fairness:
+      events (avg/stddev):           *.*/*.* (glob)
+      execution time (avg/stddev):   *.*/*.* (glob)
+  

--- a/tests/t/script_oltp_pgsql_redshift.t
+++ b/tests/t/script_oltp_pgsql_redshift.t
@@ -1,0 +1,203 @@
+########################################################################
+oltp.lua + Redshift tests 
+########################################################################
+
+  $ if [ -z "${SBTEST_PGSQL_ARGS:-}" ]
+  > then
+  >   exit 80
+  > fi
+
+  $ DB_DRIVER_ARGS="--db-driver=pgsql --pgsql-variant=redshift $SBTEST_PGSQL_ARGS"
+
+  $ function db_show_table() {
+  >  psql -c "\d+ $1" sbtest
+  > }
+
+  $ . $SBTEST_INCDIR/script_oltp_common.sh
+  sysbench *:  multi-threaded system evaluation benchmark (glob)
+  
+  Creating table 'sbtest1'...
+  Inserting 10000 records into 'sbtest1'
+  Creating secondary indexes on 'sbtest1'...
+  Creating table 'sbtest2'...
+  Inserting 10000 records into 'sbtest2'
+  Creating secondary indexes on 'sbtest2'...
+  Creating table 'sbtest3'...
+  Inserting 10000 records into 'sbtest3'
+  Creating secondary indexes on 'sbtest3'...
+  Creating table 'sbtest4'...
+  Inserting 10000 records into 'sbtest4'
+  Creating secondary indexes on 'sbtest4'...
+  Creating table 'sbtest5'...
+  Inserting 10000 records into 'sbtest5'
+  Creating secondary indexes on 'sbtest5'...
+  Creating table 'sbtest6'...
+  Inserting 10000 records into 'sbtest6'
+  Creating secondary indexes on 'sbtest6'...
+  Creating table 'sbtest7'...
+  Inserting 10000 records into 'sbtest7'
+  Creating secondary indexes on 'sbtest7'...
+  Creating table 'sbtest8'...
+  Inserting 10000 records into 'sbtest8'
+  Creating secondary indexes on 'sbtest8'...
+                                                   Table "public.sbtest1"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest1_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest1_pkey" PRIMARY KEY, btree (id)
+      "k_1" btree (k)
+  
+                                                   Table "public.sbtest2"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest2_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest2_pkey" PRIMARY KEY, btree (id)
+      "k_2" btree (k)
+  
+                                                   Table "public.sbtest3"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest3_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest3_pkey" PRIMARY KEY, btree (id)
+      "k_3" btree (k)
+  
+                                                   Table "public.sbtest4"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest4_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest4_pkey" PRIMARY KEY, btree (id)
+      "k_4" btree (k)
+  
+                                                   Table "public.sbtest5"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest5_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest5_pkey" PRIMARY KEY, btree (id)
+      "k_5" btree (k)
+  
+                                                   Table "public.sbtest6"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest6_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest6_pkey" PRIMARY KEY, btree (id)
+      "k_6" btree (k)
+  
+                                                   Table "public.sbtest7"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest7_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest7_pkey" PRIMARY KEY, btree (id)
+      "k_7" btree (k)
+  
+                                                   Table "public.sbtest8"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest8_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest8_pkey" PRIMARY KEY, btree (id)
+      "k_8" btree (k)
+  
+  Did not find any relation named "sbtest9".
+  sysbench *:  multi-threaded system evaluation benchmark (glob)
+  
+  Running the test with following options:
+  Number of threads: 1
+  Initializing random number generator from current time
+  
+  
+  Initializing worker threads...
+  
+  Threads started!
+  
+  OLTP test statistics:
+      queries performed:
+          read:                            1400
+          write:                           400
+          other:                           200
+          total:                           2000
+      transactions:                        100    (* per sec.) (glob)
+      read/write requests:                 1800   (* per sec.) (glob)
+      other operations:                    200    (* per sec.) (glob)
+      ignored errors:                      0      (* per sec.) (glob)
+      reconnects:                          0      (* per sec.) (glob)
+  
+  General statistics:
+      total time:                          *s (glob)
+      total number of events:              100
+      total time taken by event execution: *s (glob)
+      response time:
+           min:                               *ms (glob)
+           avg:                               *ms (glob)
+           max:                               *ms (glob)
+           approx.  95 percentile:            *ms (glob)
+  
+  Threads fairness:
+      events (avg/stddev):           */* (glob)
+      execution time (avg/stddev):   */* (glob)
+  
+  sysbench *:  multi-threaded system evaluation benchmark (glob)
+  
+  Dropping table 'sbtest1'...
+  Dropping table 'sbtest2'...
+  Dropping table 'sbtest3'...
+  Dropping table 'sbtest4'...
+  Dropping table 'sbtest5'...
+  Dropping table 'sbtest6'...
+  Dropping table 'sbtest7'...
+  Dropping table 'sbtest8'...
+  Did not find any relation named "sbtest1".
+  Did not find any relation named "sbtest2".
+  Did not find any relation named "sbtest3".
+  Did not find any relation named "sbtest4".
+  Did not find any relation named "sbtest5".
+  Did not find any relation named "sbtest6".
+  Did not find any relation named "sbtest7".
+  Did not find any relation named "sbtest8".
+  sysbench 1.0:  multi-threaded system evaluation benchmark (glob)
+  
+  Creating table 'sbtest1'...
+  Inserting 10000 records into 'sbtest1'
+                                                   Table "public.sbtest1"
+   Column |      Type      |                      Modifiers                       | Storage  | Stats target | Description 
+  --------+----------------+------------------------------------------------------+----------+--------------+-------------
+   id     | integer        | not null default nextval('sbtest1_id_seq'::regclass) | plain    |              | 
+   k      | integer        | not null default 0                                   | plain    |              | 
+   c      | character(120) | not null default ''::bpchar                          | extended |              | 
+   pad    | character(60)  | not null default ''::bpchar                          | extended |              | 
+  Indexes:
+      "sbtest1_pkey" PRIMARY KEY, btree (id)
+  
+  sysbench *:  multi-threaded system evaluation benchmark (glob)
+  
+  Dropping table 'sbtest1'...


### PR DESCRIPTION
This Pull Request adds AWS Redshift support.

Its a minor change that allows the pgsql infrastructure to be reused for testing a RedShift database. In my basic checks, most simple tests are working (oltp / delete / insert etc..).

- Optimizations are probably pending. This just gets the ball rolling.
- Have added two test scripts (essentially a copy of pgsql tests) although don't (yet) know how to actually get cram (and the tests going). Hope the integrated tests here would tell me if this succeeds.

- To run the test we need to pass "--pgsql-variant=redshift" as one of the options in *both* 'prepare' and 'run' cycles.