### PR TITLE
Corrected minor typo that was causing pgsql to fail on select_random_xx tests

### DIFF
--- a/sysbench/tests/db/select_random_points.lua
+++ b/sysbench/tests/db/select_random_points.lua
@@ -38,7 +38,7 @@ function prepare()
    elseif (db_driver == "pgsql") then
       query = [[
         CREATE TABLE sbtest (
-          id ]] .. (sb.oltp_auto_inc and "SERIAL") or "" .. [[,
+          id ]] .. ((oltp_auto_inc and "SERIAL") or "") .. [[,
           k INTEGER DEFAULT '0' NOT NULL,
           c CHAR(120) DEFAULT '' NOT NULL,
           pad CHAR(60) DEFAULT '' NOT NULL, 

--- a/sysbench/tests/db/select_random_ranges.lua
+++ b/sysbench/tests/db/select_random_ranges.lua
@@ -38,7 +38,7 @@ function prepare()
    elseif (db_driver == "pgsql") then
       query = [[
         CREATE TABLE sbtest (
-          id ]] .. (sb.oltp_auto_inc and "SERIAL") or "" .. [[,
+          id ]] .. ((oltp_auto_inc and "SERIAL") or "") .. [[,
           k INTEGER DEFAULT '0' NOT NULL,
           c CHAR(120) DEFAULT '' NOT NULL,
           pad CHAR(60) DEFAULT '' NOT NULL, 


### PR DESCRIPTION
Corrected minor typo that was causing test to fail on Postgres on select_random_xxx tests.

Probably this never ran after the auto_inc check was added. I was tempted to add at least a Redshift related String in the empty "", but refrained until that other PR was accepted.