### PR TITLE
Add AWS Redshift support for sysbench

### DIFF
--- a/sysbench/tests/db/common.lua
+++ b/sysbench/tests/db/common.lua
@@ -17,6 +17,12 @@ function create_insert(table_id)
      index_name = "PRIMARY KEY"
    end
 
+   if (pgsql_variant == 'redshift') then
+      auto_inc_type = "INTEGER IDENTITY(1,1)"
+   else
+      auto_inc_type = "SERIAL"
+   end
+
    i = table_id
 
    print("Creating table 'sbtest" .. i .. "'...")
@@ -36,7 +42,7 @@ pad CHAR(60) DEFAULT '' NOT NULL,
    elseif (db_driver == "pgsql") then
       query = [[
 CREATE TABLE sbtest]] .. i .. [[ (
-id SERIAL NOT NULL,
+id ]] .. auto_inc_type .. [[ NOT NULL,
 k INTEGER DEFAULT '0' NOT NULL,
 c CHAR(120) DEFAULT '' NOT NULL,
 pad CHAR(60) DEFAULT '' NOT NULL,
@@ -174,6 +180,11 @@ function set_vars()
       oltp_create_secondary = false
    else
       oltp_create_secondary = true
+   end
+
+   if (pgsql_variant == 'redshift') then
+      oltp_create_secondary = false
+      oltp_delete_inserts = 0
    end
 
 end

--- a/tests/t/drivers.t
+++ b/tests/t/drivers.t
@@ -18,5 +18,5 @@ Make sure all available DB drivers are covered
   
   Dropping table 'sbtest1'...
   FATAL: invalid database driver name: 'nonexisting'
-  FATAL: failed to execute function `cleanup': */common.lua:122: DB initialization failed (glob)
+  FATAL: failed to execute function `cleanup': */common.lua:128: DB initialization failed (glob)
   [1]


### PR DESCRIPTION
This Pull Request adds AWS Redshift support.

This is a minor change that allows the pgsql infrastructure to be reused for testing a RedShift DB. In my basic checks, most simple tests are working (oltp / delete / insert etc..).

Optimizations are probably pending, but this gets the ball rolling.

To run the test we need to pass "--pgsql-variant=redshift" as one of the options in both 'prepare' and 'run' cycles.