### PR TITLE
Add snap packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ tests/t/*.err
 /src/lua/internal/sysbench.cmdline.lua.h
 /src/lua/internal/sysbench.compat.lua.h
 /src/lua/internal/sysbench.histogram.lua.h
+parts
+prime
+stage
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: sysbench
+version: 1.0.0
+summary: Cross-platform and multi-threaded benchmark tool
+description: |
+ sysbench is a modular, cross-platform and multi-threaded benchmark tool for
+ evaluating OS parameters that are important for a system running a database
+ under intensive load.
+
+ The idea of this benchmark suite is to quickly get an impression about system
+ performance without setting up complex database benchmarks or even without
+ installing a database at all.
+
+ Current features allow to test the following system parameters:
+  * file I/O performance
+  * scheduler performance
+  * memory allocation and transfer speed
+  * POSIX threads implementation performance
+  * database server performance (OLTP benchmark)
+grade: stable
+confinement: classic
+
+apps:
+  sysbench:
+    command: sysbench
+    plugs:
+      - network
+
+parts:
+  sysbench:
+    source: .
+    plugin: autotools
+    build-packages:
+      - libmysqlclient-dev
+    stage-packages:
+      - libmysqlclient20
+      - libaio1


### PR DESCRIPTION
Add snapcraft.yaml for use with the snapcraft tool for
producing snap packages for sysbench.

For more details on snappy and snap packages see:

  https://snapcraft.io