### PR TITLE
fix typo in --rand-pareto-h description

### DIFF
--- a/src/sb_rand.c
+++ b/src/sb_rand.c
@@ -60,7 +60,7 @@ static sb_arg_t rand_args[] =
   SB_OPT("rand-seed",
          "seed for random number generator. When 0, the current time is "
          "used as a RNG seed.", "0", INT),
-  SB_OPT("rand-pareto-h", "parameter h for pareto distibution", "0.2", DOUBLE),
+  SB_OPT("rand-pareto-h", "parameter h for pareto distribution", "0.2", DOUBLE),
 
   SB_OPT_END
 };

--- a/tests/t/api_reports.t
+++ b/tests/t/api_reports.t
@@ -21,8 +21,8 @@ Tests for custom report hooks
   > EOF
 
   $ sysbench $SB_ARGS run
-  \[ 2s \] thds: 1 tps: [0-9]*\.[0-9]* qps: 0\.00 \(r\/w\/o: 0\.00\/0\.00\/0\.00\) lat \(ms,95%\): [1-9][0-9]*\.[0-9]* err\/s 0\.00 reconn\/s: 0\.00 (re)
-  \[ 3s \] thds: 0 tps: [0-9]*\.[0-9]* qps: 0\.00 \(r\/w\/o: 0\.00\/0\.00\/0\.00\) lat \(ms,95%\): [1-9][0-9]*\.[0-9]* err\/s 0\.00 reconn\/s: 0\.00 (re)
+  [ 2s ] thds: 1 tps: *.* qps: 0.00 (r/w/o: 0.00/0.00/0.00) lat (ms,95%): 1.* err/s 0.00 reconn/s: 0.00 (glob)
+  [ 3s ] thds: 0 tps: *.* qps: 0.00 (r/w/o: 0.00/0.00/0.00) lat (ms,95%): 1.* err/s 0.00 reconn/s: 0.00 (glob)
 
 ########################################################################
 # CSV format via a custom hook
@@ -40,8 +40,8 @@ Tests for custom report hooks
   > EOF
 
   $ sysbench $SB_ARGS run
-  2,1,[0-9]*\.[0-9]*,0\.00,0\.00,0\.00,0\.00,[1-9][0-9]*\.[0-9]*,0\.00,0\.00 (re)
-  3,0,[0-9]*\.[0-9]*,0\.00,0\.00,0\.00,0\.00,[1-9][0-9]*\.[0-9]*,0\.00,0\.00 (re)
+  2,1,*.*,0.00,0.00,0.00,0.00,1.*,0.00,0.00 (glob)
+  3,0,*.*,0.00,0.00,0.00,0.00,1.*,0.00,0.00 (glob)
 
 ########################################################################
 # JSON format via a custom hook
@@ -69,7 +69,7 @@ Tests for custom report hooks
       "writes": 0.00,
       "other": 0.00,
     },
-    "latency": [1-9][0-9]*\.[0-9]*, (re)
+    "latency": 1.*, (glob)
     "errors": 0.00,
     "reconnects": 0.00
   },
@@ -83,7 +83,7 @@ Tests for custom report hooks
       "writes": 0.00,
       "other": 0.00,
     },
-    "latency": [1-9][0-9]*\.[0-9]*, (re)
+    "latency": 1.*, (glob)
     "errors": 0.00,
     "reconnects": 0.00
   },

--- a/tests/t/api_reports.t
+++ b/tests/t/api_reports.t
@@ -21,8 +21,8 @@ Tests for custom report hooks
   > EOF
 
   $ sysbench $SB_ARGS run
-  [ 2s ] thds: 1 tps: *.* qps: 0.00 (r/w/o: 0.00/0.00/0.00) lat (ms,95%): 1.* err/s 0.00 reconn/s: 0.00 (glob)
-  [ 3s ] thds: 0 tps: *.* qps: 0.00 (r/w/o: 0.00/0.00/0.00) lat (ms,95%): 1.* err/s 0.00 reconn/s: 0.00 (glob)
+  \[ 2s \] thds: 1 tps: [0-9]*\.[0-9]* qps: 0\.00 \(r\/w\/o: 0\.00\/0\.00\/0\.00\) lat \(ms,95%\): [1-9][0-9]*\.[0-9]* err\/s 0\.00 reconn\/s: 0\.00 (re)
+  \[ 3s \] thds: 0 tps: [0-9]*\.[0-9]* qps: 0\.00 \(r\/w\/o: 0\.00\/0\.00\/0\.00\) lat \(ms,95%\): [1-9][0-9]*\.[0-9]* err\/s 0\.00 reconn\/s: 0\.00 (re)
 
 ########################################################################
 # CSV format via a custom hook
@@ -40,8 +40,8 @@ Tests for custom report hooks
   > EOF
 
   $ sysbench $SB_ARGS run
-  2,1,*.*,0.00,0.00,0.00,0.00,1.*,0.00,0.00 (glob)
-  3,0,*.*,0.00,0.00,0.00,0.00,1.*,0.00,0.00 (glob)
+  2,1,[0-9]*\.[0-9]*,0\.00,0\.00,0\.00,0\.00,[1-9][0-9]*\.[0-9]*,0\.00,0\.00 (re)
+  3,0,[0-9]*\.[0-9]*,0\.00,0\.00,0\.00,0\.00,[1-9][0-9]*\.[0-9]*,0\.00,0\.00 (re)
 
 ########################################################################
 # JSON format via a custom hook
@@ -69,7 +69,7 @@ Tests for custom report hooks
       "writes": 0.00,
       "other": 0.00,
     },
-    "latency": 1.*, (glob)
+    "latency": [1-9][0-9]*\.[0-9]*, (re)
     "errors": 0.00,
     "reconnects": 0.00
   },
@@ -83,7 +83,7 @@ Tests for custom report hooks
       "writes": 0.00,
       "other": 0.00,
     },
-    "latency": 1.*, (glob)
+    "latency": [1-9][0-9]*\.[0-9]*, (re)
     "errors": 0.00,
     "reconnects": 0.00
   },

--- a/tests/t/opt_help.t
+++ b/tests/t/opt_help.t
@@ -39,7 +39,7 @@ separately.
     --rand-spec-pct=N  percentage of values to be treated as 'special' (for special distribution) [1]
     --rand-spec-res=N  percentage of 'special' values to use (for special distribution) [75]
     --rand-seed=N      seed for random number generator. When 0, the current time is used as a RNG seed. [0]
-    --rand-pareto-h=N  parameter h for pareto distibution [0.2]
+    --rand-pareto-h=N  parameter h for pareto distribution [0.2]
   
   Log options:
     --verbosity=N verbosity level {5 - debug, 0 - only critical messages} [3]


### PR DESCRIPTION
got a lintian hit for this when working on updating the debian package