### PR TITLE
fix api_report test latency check

### DIFF
--- a/tests/t/api_reports.t
+++ b/tests/t/api_reports.t
@@ -21,8 +21,8 @@ Tests for custom report hooks
   > EOF
 
   $ sysbench $SB_ARGS run
-  [ 2s ] thds: 1 tps: *.* qps: 0.00 (r/w/o: 0.00/0.00/0.00) lat (ms,95%): 1.* err/s 0.00 reconn/s: 0.00 (glob)
-  [ 3s ] thds: 0 tps: *.* qps: 0.00 (r/w/o: 0.00/0.00/0.00) lat (ms,95%): 1.* err/s 0.00 reconn/s: 0.00 (glob)
+  \[ 2s \] thds: 1 tps: [0-9]*\.[0-9]* qps: 0\.00 \(r\/w\/o: 0\.00\/0\.00\/0\.00\) lat \(ms,95%\): [1-9][0-9]*\.[0-9]* err\/s 0\.00 reconn\/s: 0\.00 (re)
+  \[ 3s \] thds: 0 tps: [0-9]*\.[0-9]* qps: 0\.00 \(r\/w\/o: 0\.00\/0\.00\/0\.00\) lat \(ms,95%\): [1-9][0-9]*\.[0-9]* err\/s 0\.00 reconn\/s: 0\.00 (re)
 
 ########################################################################
 # CSV format via a custom hook
@@ -40,8 +40,8 @@ Tests for custom report hooks
   > EOF
 
   $ sysbench $SB_ARGS run
-  2,1,*.*,0.00,0.00,0.00,0.00,1.*,0.00,0.00 (glob)
-  3,0,*.*,0.00,0.00,0.00,0.00,1.*,0.00,0.00 (glob)
+  2,1,[0-9]*\.[0-9]*,0\.00,0\.00,0\.00,0\.00,[1-9][0-9]*\.[0-9]*,0\.00,0\.00 (re)
+  3,0,[0-9]*\.[0-9]*,0\.00,0\.00,0\.00,0\.00,[1-9][0-9]*\.[0-9]*,0\.00,0\.00 (re)
 
 ########################################################################
 # JSON format via a custom hook
@@ -69,7 +69,7 @@ Tests for custom report hooks
       "writes": 0.00,
       "other": 0.00,
     },
-    "latency": 1.*, (glob)
+    "latency": [1-9][0-9]*\.[0-9]*, (re)
     "errors": 0.00,
     "reconnects": 0.00
   },
@@ -83,7 +83,7 @@ Tests for custom report hooks
       "writes": 0.00,
       "other": 0.00,
     },
-    "latency": 1.*, (glob)
+    "latency": [1-9][0-9]*\.[0-9]*, (re)
     "errors": 0.00,
     "reconnects": 0.00
   },


### PR DESCRIPTION
Modify test to permit latency values >= 2, preventing test failure when available cpu resources are limited. Without this change, one can get the test to fail by running it while the cpu is under high load causing the latency to exceed the expected value of 1.* ms (glob).

By using [1-9][0-9]*\.[0-9]* (re) rather than *.* (glob) in place of the previous 1.* (glob) the modified test still requires the latency to have a value >= 1 ms as dictated by the usleep(1000) statement. Note that the proposed change does not set an upper limit on the latency, although it would be possible to modify the regexp to that effect.
