### PR TITLE
sb_fileio.c: suggest to run prepare step

### DIFF
--- a/src/tests/fileio/sb_fileio.c
+++ b/src/tests/fileio/sb_fileio.c
@@ -376,6 +376,7 @@ int file_prepare(void)
     if (!VALID_FILE(files[i]))
     {
       log_errno(LOG_FATAL, "Cannot open file '%s'", file_name);
+      log_text(LOG_WARNING, "Did you forget to run the prepare step?");
       return 1; 
     }
   }


### PR DESCRIPTION
A recurring reason for errors is forgetting to run the prepare
step before running the file io test.

Write a warning line suggesting to run prepare.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>