### PR TITLE
Tolerate non-block-aligned test files. ...

### DIFF
--- a/src/tests/fileio/sb_fileio.c
+++ b/src/tests/fileio/sb_fileio.c
@@ -533,7 +533,11 @@ sb_event_t file_get_seq_request(void)
   }
   else
   {
-    file_req->size = file_block_size;
+    if (position + file_max_request_size > file_size)
+      file_req->size = file_size - position;
+    else
+      file_req->size = file_block_size;
+
     file_req->file_id = current_file;
     file_req->pos = position;
   }


### PR DESCRIPTION
Files created with combinations of file-num and file-total-size that are
not an exact multiple of the block size cause a crash with "Too large
position discovered in request!". prepare will happily create such
files, so sysbench should not crash trying to test them.