### PR TITLE
Drop htmldir as it defaults to docdir if unset.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,7 +4,6 @@ XHTML_STYLESHEET=$(srcdir)/xsl/xhtml.xsl
 CHUNK_XHTML_STYLESHEET=$(srcdir)/xsl/xhtml-chunk.xsl
 XML_CATALOG_FILES=$(srcdir)/xsl/catalog.xml
 
-htmldir = $(prefix)/share/doc/sysbench
 dist_html_DATA = manual.html
 
 EXTRA_DIST=manual.xml


### PR DESCRIPTION
The htmldir variable defaults to docdir since autoconf 2.60 (2006).

https://lists.gnu.org/archive/html/automake/2008-09/msg00006.html