### PR TITLE
m4/ax_gcc_archflag: include POWER7 -> POWER10

### DIFF
--- a/m4/ax_gcc_archflag.m4
+++ b/m4/ax_gcc_archflag.m4
@@ -198,6 +198,10 @@ case $host_cpu in
        *POWER4*|*power4*|*gq*) ax_gcc_arch="power4 970";;
        *POWER5*|*power5*|*gr*|*gs*) ax_gcc_arch="power5 power4 970";;
        603ev|8240) ax_gcc_arch="$cputype 603e 603";;
+       *POWER7*) ax_gcc_arch="power7";;
+       *POWER8*) ax_gcc_arch="power8";;
+       *POWER9*) ax_gcc_arch="power9";;
+       *POWER10*) ax_gcc_arch="power10";;
        *) ax_gcc_arch=$cputype ;;
      esac
      ax_gcc_arch="$ax_gcc_arch powerpc"


### PR DESCRIPTION
POWER6 is missing - couldn't find hardware to test (and it was
a long time ago).

Tested on P7 - P9.

Added POWER10 as its in development and unlikely to change

Have submitted this upstream: https://github.com/autoconf-archive/autoconf-archive/pull/175