### PR TITLE
Fix #287: Issue of MYSQL_OPT_SSL_MODE

### DIFF
--- a/m4/sb_check_mysql.m4
+++ b/m4/sb_check_mysql.m4
@@ -114,7 +114,24 @@ AC_DEFINE([USE_MYSQL], 1,
 USE_MYSQL=1
 AC_SUBST([MYSQL_LIBS])
 AC_SUBST([MYSQL_CFLAGS])
+
+AC_MSG_CHECKING([if mysql.h defines MYSQL_OPT_SSL_MODE])
+
+SAVE_CFLAGS="${CFLAGS}"
+CFLAGS="${CFLAGS} ${MYSQL_CFLAGS}"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+        [[
+#include <mysql.h>
+
+enum mysql_option opt = MYSQL_OPT_SSL_MODE;
+        ]])], [
+          AC_DEFINE([HAVE_MYSQL_OPT_SSL_MODE], 1,
+                    [Define to 1 if mysql.h defines MYSQL_OPT_SSL_MODE])
+          AC_MSG_RESULT([yes])
+          ], [AC_MSG_RESULT([no])])
 ])
+CFLAGS="${SAVE_CFLAGS}"
+
 
 AM_CONDITIONAL([USE_MYSQL], test "x$with_mysql" != xno)
 AC_SUBST([USE_MYSQL])

--- a/src/drivers/mysql/drv_mysql.c
+++ b/src/drivers/mysql/drv_mysql.c
@@ -323,10 +323,10 @@ static int mysql_drv_real_connect(db_mysql_conn_t *db_mysql_con)
 
     mysql_ssl_set(con, ssl_key, ssl_cert, ssl_ca, NULL, args.ssl_cipher);
 
-#ifdef MYSQL_OPT_SSL_MODE
+#ifdef HAVE_MYSQL_OPT_SSL_MODE
     unsigned int opt_ssl_mode = SSL_MODE_REQUIRED;
 
-    DEBUG("mysql_options(%p,%s,%u)", con, "MYSQL_OPT_SSL_MODE", opt_ssl_mode);
+    DEBUG("mysql_options(%p, %s, %u)", con, "MYSQL_OPT_SSL_MODE", opt_ssl_mode);
     mysql_options(con, MYSQL_OPT_SSL_MODE, &opt_ssl_mode);
 #endif
   }


### PR DESCRIPTION
In drv_mysql.c do not assume MYSQL_OPT_SSL_MODE to be a preprocessor
define. It is an mysql_option enum value with all MySQL
versions. Instead, do a configure-time check if that value is defined in
mysql.h.