### PR TITLE
lua return value of sb_rand_varstr

### DIFF
--- a/src/lua/internal/sysbench.rand.lua
+++ b/src/lua/internal/sysbench.rand.lua
@@ -32,7 +32,7 @@ uint32_t sb_rand_pareto(uint32_t, uint32_t);
 uint32_t sb_rand_zipfian(uint32_t, uint32_t);
 uint32_t sb_rand_unique(void);
 void sb_rand_str(const char *, char *);
-void sb_rand_varstr(char *, uint32_t, uint32_t);
+uint32_t sb_rand_varstr(char *, uint32_t, uint32_t);
 double sb_rand_uniform_double(void);
 ]]
 


### PR DESCRIPTION
The sb_rand_varstr return value is used by sysbench.rand.varstr