### PR TITLE
Rm local declarations to let scripts add queries

### DIFF
--- a/src/lua/oltp_common.lua
+++ b/src/lua/oltp_common.lua
@@ -137,13 +137,13 @@ sysbench.cmdline.commands = {
 -- Template strings of random digits with 11-digit groups separated by dashes
 
 -- 10 groups, 119 characters
-local c_value_template = "###########-###########-###########-" ..
+c_value_template = "###########-###########-###########-" ..
    "###########-###########-###########-" ..
    "###########-###########-###########-" ..
    "###########"
 
 -- 5 groups, 59 characters
-local pad_value_template = "###########-###########-###########-" ..
+pad_value_template = "###########-###########-###########-" ..
    "###########-###########"
 
 function get_c_value()
@@ -247,8 +247,8 @@ CREATE TABLE sbtest%d(
    end
 end
 
-local t = sysbench.sql.type
-local stmt_defs = {
+t = sysbench.sql.type
+stmt_defs = {
    point_selects = {
       "SELECT c FROM sbtest%u WHERE id=?",
       t.INT},
@@ -277,6 +277,7 @@ local stmt_defs = {
       "INSERT INTO sbtest%u (id, k, c, pad) VALUES (?, ?, ?, ?)",
       t.INT, t.INT, {t.CHAR, 120}, {t.CHAR, 60}},
 }
+
 
 function prepare_begin()
    stmt.begin = con:prepare("BEGIN")
@@ -400,11 +401,11 @@ function cleanup()
    end
 end
 
-local function get_table_num()
+function get_table_num()
    return sysbench.rand.uniform(1, sysbench.opt.tables)
 end
 
-local function get_id()
+function get_id()
    return sysbench.rand.default(1, sysbench.opt.table_size)
 end
 


### PR DESCRIPTION
Hi,

I was wondering why these variables were 'local' ?
Removing it would allow scripts to add a custom query (in my case, queries to reproduce full scans, bad joins, or regular joins) while keeping all the boilerplate to prepare queries and execute them

With this additions, it let me do this in my personal bench:
```  
    function execute_fullscans()
	 local tnum = get_table_num()
	param[tnum].fullscans[1]:set_rand_str("%###")
        stmt[tnum].fullscans:execute()
    end

    stmt_defs.fullscans = {
        "SELECT c FROM sbtest%u WHERE pad=?",
        {t.CHAR, 60} }
```

Beside general local / global principles, is there any downside to this ? Performance-wise ? 

Thanks