### PR TITLE
Update deb dependencies for debian buster

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: sysbench
 Section: misc
 Priority: extra
 Maintainer: Alexey Kopytov <akopytov@gmail.com>
-Build-Depends: debhelper, autoconf, automake, libaio-dev, libtool, libmysqlclient-dev | default-libmysqlclient-dev, libpq-dev, pkg-config, python
+Build-Depends: debhelper, autoconf, automake, libaio-dev, libtool, libmysqlclient-dev | default-libmysqlclient-dev | libmariadb-dev-compat, libpq-dev, pkg-config, python
 Standards-Version: 3.9.5
 Homepage: https://github.com/akopytov/sysbench
 


### PR DESCRIPTION
When i tried to build deb package on debian buster, apt-ge suggested that i should install libmariadb-dev-compat and libmariadb-dev instead of libmysqlclient-dev. And since libmariadb-dev-compat already depends on libmariadb-dev, I think adding libmariadb-dev-compat todependency list solves the issue.

If libmariadb-dev-compat not exists in build-depends list, then dpkg-buildpackage fails o build deb package.