### PR TITLE
sopport misp arch

### DIFF
--- a/third_party/concurrency_kit/ck/configure
+++ b/third_party/concurrency_kit/ck/configure
@@ -434,6 +434,13 @@ case $PLATFORM in
 				;;
 		esac
 		;;
+	"mips64")
+		LSE_ENABLE="CK_MD_LSE_DISABLE"
+		PLATFORM=mips
+		ENVIRONMENT=64
+		LDFLAGS="$LDFLAGS"
+		MM="${MM:-"CK_MD_TSO"}"
+		;;
 	"amd64"|"x86_64")
 		LSE_ENABLE="CK_MD_LSE_DISABLE"
 		PLATFORM=x86_64


### PR DESCRIPTION
1. Modify configuration file in concurrency_kit. Support for mips arch.
2. Add empty ck build file for mips arch.