### PR TITLE
Add memory latency support

### DIFF
--- a/src/tests/memory/sb_memory.c
+++ b/src/tests/memory/sb_memory.c
@@ -45,7 +45,7 @@ static sb_arg_t memory_args[] =
 #ifdef HAVE_LARGE_PAGES
   SB_OPT("memory-hugetlb", "allocate memory from HugeTLB pool", "off", BOOL),
 #endif
-  SB_OPT("memory-oper", "type of memory operations {read, write, none}",
+  SB_OPT("memory-oper", "type of memory operations {read, write, latency, none}",
          "write", STRING),
   SB_OPT("memory-access-mode", "memory access mode {seq,rnd}", "seq", STRING),
 
@@ -62,6 +62,7 @@ static int event_rnd_write(sb_event_t *, int);
 static int event_seq_none(sb_event_t *, int);
 static int event_seq_read(sb_event_t *, int);
 static int event_seq_write(sb_event_t *, int);
+static int event_latency(sb_event_t *, int);
 static void memory_report_intermediate(sb_stat_t *);
 static void memory_report_cumulative(sb_stat_t *);
 
@@ -79,6 +80,14 @@ static sb_test_t memory_test =
   .args = memory_args
 };
 
+/* A struct that aligns to cache lines */
+struct Node {
+  union {
+    struct Node *next;
+    char padding[64]; /* 64 = cache line size */
+  };
+};
+
 /* Test arguments */
 
 static ssize_t memory_block_size;
@@ -86,6 +95,7 @@ static long long    memory_total_size;
 static unsigned int memory_scope;
 static unsigned int memory_oper;
 static unsigned int memory_access_rnd;
+static struct Node *nodes; /* only used for measuring latency */
 #ifdef HAVE_LARGE_PAGES
 static unsigned int memory_hugetlb;
 #endif
@@ -114,8 +124,25 @@ int memory_init(void)
   char         *s;
   size_t       *buffer;
 
+  s = sb_get_value_string("memory-oper");
+  if (!strcmp(s, "write"))
+    memory_oper = SB_MEM_OP_WRITE;
+  else if (!strcmp(s, "read"))
+    memory_oper = SB_MEM_OP_READ;
+  else if (!strcmp(s, "latency"))
+    memory_oper = SB_MEM_OP_LATENCY;
+  else if (!strcmp(s, "none"))
+    memory_oper = SB_MEM_OP_NONE;
+  else
+  {
+    log_text(LOG_FATAL, "Invalid value for memory-oper: %s", s);
+    return 1;
+  }
+
+
   memory_block_size = sb_get_value_size("memory-block-size");
-  if (memory_block_size < SIZEOF_SIZE_T ||
+  if ((memory_oper != SB_MEM_OP_LATENCY && memory_block_size < SIZEOF_SIZE_T) ||
+      (memory_oper == SB_MEM_OP_LATENCY && memory_block_size < 64) ||
       /* Must be a power of 2 */
       (memory_block_size & (memory_block_size - 1)) != 0)
   {
@@ -124,7 +151,8 @@ int memory_init(void)
     return 1;
   }
 
-  max_offset = memory_block_size / SIZEOF_SIZE_T - 1;
+  const ssize_t testing_struct_size = SB_MEM_OP_LATENCY ? 64 : SIZEOF_SIZE_T;
+  max_offset = memory_block_size / testing_struct_size - 1;
 
   memory_total_size = sb_get_value_size("memory-total-size");
 
@@ -142,19 +170,6 @@ int memory_init(void)
 #ifdef HAVE_LARGE_PAGES
     memory_hugetlb = sb_get_value_flag("memory-hugetlb");
 #endif  
-
-  s = sb_get_value_string("memory-oper");
-  if (!strcmp(s, "write"))
-    memory_oper = SB_MEM_OP_WRITE;
-  else if (!strcmp(s, "read"))
-    memory_oper = SB_MEM_OP_READ;
-  else if (!strcmp(s, "none"))
-    memory_oper = SB_MEM_OP_NONE;
-  else
-  {
-    log_text(LOG_FATAL, "Invalid value for memory-oper: %s", s);
-    return 1;
-  }
 
   s = sb_get_value_string("memory-access-mode");
   if (!strcmp(s, "seq"))
@@ -182,7 +197,24 @@ int memory_init(void)
       return 1;
     }
 
-    memset(buffer, 0, memory_block_size);
+    if (memory_oper == SB_MEM_OP_LATENCY)
+    {
+      /* Generate a random circle link list */
+      nodes = (struct Node*)buffer;
+      nodes[0].next = nodes;
+      for (int i = 1; i <= max_offset; ++i)
+      {
+        struct Node *cur = nodes + sb_rand_default(0, i-1);
+        struct Node *nxt = cur->next;
+        struct Node *tail = nodes + i;
+        cur->next = tail;
+        tail->next = nxt;
+      }
+    }
+    else
+    {
+      memset(buffer, 0, memory_block_size);
+    }
   }
 
   thread_counters = malloc(sb_globals.threads * sizeof(uint64_t));
@@ -215,8 +247,9 @@ int memory_init(void)
       memset(buffers[i], 0, memory_block_size);
     }
 
+    const ssize_t one_pass = memory_oper == SB_MEM_OP_LATENCY ? (((ssize_t)1)<<20) : memory_block_size;
     thread_counters[i] =
-      memory_total_size / memory_block_size / sb_globals.threads;
+      memory_total_size / one_pass / sb_globals.threads;
   }
 
   switch (memory_oper) {
@@ -233,6 +266,14 @@ int memory_init(void)
   case SB_MEM_OP_WRITE:
     memory_test.ops.execute_event =
       memory_access_rnd ? event_rnd_write : event_seq_write;
+    break;
+
+  case SB_MEM_OP_LATENCY:
+    if (sb_globals.threads != 1 || memory_scope != SB_MEM_SCOPE_GLOBAL) {
+      log_text(LOG_FATAL, "Memory latency accepts only --memory-scope=global and --threads=1!");
+      return 1;
+    }
+    memory_test.ops.execute_event = event_latency;
     break;
 
   default:
@@ -363,6 +404,27 @@ int event_seq_write(sb_event_t *req, int tid)
 }
 
 
+int event_latency(sb_event_t *req, int tid)
+{
+  (void) req; /* unused */
+  (void) tid; /* unused */
+  struct Node *nodes_tmp = nodes;
+  /* totally 1M times */
+  for (size_t i = 0; i < (1<<17); ++i)
+  {
+    nodes_tmp = nodes_tmp->next;
+    nodes_tmp = nodes_tmp->next;
+    nodes_tmp = nodes_tmp->next;
+    nodes_tmp = nodes_tmp->next;
+    nodes_tmp = nodes_tmp->next;
+    nodes_tmp = nodes_tmp->next;
+    nodes_tmp = nodes_tmp->next;
+    nodes_tmp = nodes_tmp->next;
+  }
+  nodes = nodes_tmp;
+  return 0;
+}
+
 void memory_print_mode(void)
 {
   char *str;
@@ -379,6 +441,9 @@ void memory_print_mode(void)
       break;
     case SB_MEM_OP_WRITE:
       str = "write";
+      break;
+    case SB_MEM_OP_LATENCY:
+      str = "latency";
       break;
     case SB_MEM_OP_NONE:
       str = "none";
@@ -429,8 +494,14 @@ void memory_report_cumulative(sb_stat_t *stat)
   log_text(LOG_NOTICE, "Total operations: %" PRIu64 " (%8.2f per second)\n",
            stat->events, stat->events / stat->time_interval);
 
-  if (memory_oper != SB_MEM_OP_NONE)
+  if (memory_oper == SB_MEM_OP_LATENCY)
   {
+    const double unit = 1e9 / (1<<20); // convert second to nanosecond + events to operation count
+    log_text(LOG_NOTICE, "Memory latency %5.2f ns\n", stat->time_interval / stat->events * unit);
+  }
+  else if (memory_oper != SB_MEM_OP_NONE)
+  {
+    // read or write
     const double mb = stat->events * memory_block_size / megabyte;
     log_text(LOG_NOTICE, "%4.2f MiB transferred (%4.2f MiB/sec)\n",
              mb, mb / stat->time_interval);

--- a/src/tests/sb_memory.h
+++ b/src/tests/sb_memory.h
@@ -24,7 +24,8 @@ typedef enum
 {
   SB_MEM_OP_NONE,
   SB_MEM_OP_READ,
-  SB_MEM_OP_WRITE
+  SB_MEM_OP_WRITE,
+  SB_MEM_OP_LATENCY
 } sb_mem_op_t;
 
 


### PR DESCRIPTION
Hello, I find that it can be good to be able to measure the memory latency in sysbench, similar to AIDA64 cache & memory benchmark that works on Windows. Therefore, I try to implement a mode `--memory-oper=latency` that can measure the latency of the memory system, which can report a similar number as AIDA64. I have tried this on several systems to ensure the accuracy of this measurement, and the script I have used is:

```bash
for i in {0..16}
do
sysbench memory run --memory-oper=latency --memory-total-size=512m --memory-block-size=$((1<<$i))k | grep "Memory latency"
done
```

These are the results I collected:
**AMD 2400G+DDR4 2400**
![2400G](https://user-images.githubusercontent.com/1106799/87227618-d86e2d80-c3ce-11ea-93ec-490c863dcd5b.png)
**AMD 3700X+DDR4 3200**
![3700X](https://user-images.githubusercontent.com/1106799/87227621-da37f100-c3ce-11ea-9507-b1636884543f.png)
**AMD 4700U+LPDDR4x 4266**
![4700U](https://user-images.githubusercontent.com/1106799/87227622-dad08780-c3ce-11ea-9a18-7d0388a4ab4e.png)
**Intel 8700+DDR4 2666**
![8700](https://user-images.githubusercontent.com/1106799/87227623-dad08780-c3ce-11ea-90e8-4880ba04a7a4.png)
**Intel 9300H+DDR4 2400**
![9300H](https://user-images.githubusercontent.com/1106799/87227624-db691e00-c3ce-11ea-8aa7-bd5215febc60.png)

**This pull request**
|        | 3700x |  8700 |  2400G |  4700U | 9300H |
| -:     | -:    | -:    | -:     | -:     | -:    |
|   1 KB |  0.93 |  0.88 |   1.12 |   0.98 |  1.00 |
|   2 KB |  0.92 |  0.87 |   1.09 |   0.96 |  0.99 |
|   4 KB |  0.93 |  0.88 |   1.09 |   0.96 |  0.99 |
|   8 KB |  0.93 |  0.88 |   1.08 |   0.96 |  0.99 |
|  16 KB |  0.93 |  0.87 |   1.08 |   0.96 |  0.99 |
|  32 KB |  0.93 |  0.87 |   1.86 |   0.96 |  0.99 |
|  64 KB |  2.04 |  2.62 |   3.25 |   2.74 |  2.98 |
| 128 KB |  2.53 |  2.62 |   3.27 |   2.79 |  3.48 |
| 256 KB |  2.71 |  2.62 |   3.48 |   3.37 |  4.75 |
| 512 KB |  4.48 |  7.28 |   7.13 |   5.38 |  9.02 |
|   1 MB |  7.76 |  8.97 |  10.68 |  10.07 | 10.64 |
|   2 MB |  9.31 |  9.77 |  35.40 |  11.22 | 11.29 |
|   4 MB |  9.97 | 10.14 |  71.87 |  28.43 | 14.25 |
|   8 MB | 10.35 | 10.93 |  89.10 |  93.18 | 33.28 |
|  16 MB | 18.35 | 33.20 |  99.03 | 108.28 | 62.40 |
|  32 MB | 65.19 | 58.66 | 103.62 | 116.48 | 69.11 |
|  64 MB | 78.60 | 67.38 | 108.02 | 121.05 | 73.54 |

**AIDA64**
|        | 3700x |  8700 |  2400G |  4700U | 9300H |
| -:     | -:    | -:    | -:     | -:     | -:    |
| L1     |   1.0 |   0.9 |    1.1 |    1.0 |   1.0 |
| L2     |   2.8 |   2.6 |    3.2 |    2.9 |   3.0 |
| L3     |  10.4 |  10.9 |   10.2 |   10.4 |  11.8 |
| DRAM   |  76.5 |  61.5 |   94.3 |  119.7 |  69.3 |