### PR TITLE
Fix emulation mode string length bug.

### DIFF
--- a/src/db_driver.c
+++ b/src/db_driver.c
@@ -775,7 +775,7 @@ int db_print_value(db_bind_t *var, char *buf, int buflen)
       break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
-      n = snprintf(buf, buflen, "'%s'", (char *)var->buffer);
+      n = snprintf(buf, buflen, "'%.*s'", *var->data_len, (char *)var->buffer);
       break;
     case DB_TYPE_DATE:
       tm = (db_time_t *)var->buffer;


### PR DESCRIPTION
If string length is not specified manually, the char* buffer is not
terminated properly with a '\0'. Take an example:

```lua
"SELECT c FROM sbtest%u WHERE name=?", {t.CHAR, 120}},
```

If you bind it first with "abcd", then "123456", then again "abcd", the
SQL that is produced looks like

```
SELECT c FROM sbtest1 WHERE name='abcd'
SELECT c FROM sbtest1 WHERE name='123456'
SELECT c FROM sbtest1 WHERE name='abcd56'
```

Note 'abcd56' on the last example. With this PR this is fixed so we get

```
SELECT c FROM sbtest1 WHERE name='abcd'
SELECT c FROM sbtest1 WHERE name='123456'
SELECT c FROM sbtest1 WHERE name='abcd'
```