### PR TITLE
Prefer python3 to python2 in `test_run.sh`

### DIFF
--- a/tests/test_run.sh
+++ b/tests/test_run.sh
@@ -86,6 +86,9 @@ export LUA_PATH
 if $(command -v python >/dev/null 2>&1)
 then
     PYTHON=python
+elif $(command -v python3 >/dev/null 2>&1)
+then
+    PYTHON=python3
 elif $(command -v python2 >/dev/null 2>&1)
 then
     PYTHON=python2


### PR DESCRIPTION
Some distributions do not alias /usr/bin/python3 to /usr/bin/python