### PR TITLE
Speed up MySQL inserts during prepare

### DIFF
--- a/src/lua/oltp_common.lua
+++ b/src/lua/oltp_common.lua
@@ -287,6 +287,10 @@ function prepare_commit()
 end
 
 function prepare_for_each_table(key)
+   if drv:name() == "mysql"
+   then
+      con:query("SET autocommit=0, unique_checks=0, foreign_key_checks=0")
+   end
    for t = 1, sysbench.opt.tables do
       stmt[t][key] = con:prepare(string.format(stmt_defs[key][1], t))
 
@@ -315,6 +319,10 @@ function prepare_for_each_table(key)
       if nparam > 0 then
          stmt[t][key]:bind_param(unpack(param[t][key]))
       end
+   end
+   if drv:name() == "mysql"
+   then
+      con:query("SET autocommit=1, unique_checks=1, foreign_key_checks=1")
    end
 end
 


### PR DESCRIPTION
During `sysbench prepare`, let us use the same settings as `mysqldump` would, in an attempt to speed up `INSERT` operations.
In MariaDB/server@8ea923f55b7666a359ac2c54f6c10e8609d16846 this would result in less undo log being written.