### PR TITLE
lua: speed up creating secondary

### DIFF
--- a/src/lua/oltp_common.lua
+++ b/src/lua/oltp_common.lua
@@ -202,6 +202,13 @@ CREATE TABLE sbtest%d(
 
    con:query(query)
 
+   if sysbench.opt.create_secondary then
+      print(string.format("Creating a secondary index on 'sbtest%d'...",
+                          table_num))
+      con:query(string.format("CREATE INDEX k_%d ON sbtest%d(k)",
+                              table_num, table_num))
+   end
+
    if (sysbench.opt.table_size > 0) then
       print(string.format("Inserting %d records into 'sbtest%d'",
                           sysbench.opt.table_size, table_num))
@@ -238,13 +245,6 @@ CREATE TABLE sbtest%d(
    end
 
    con:bulk_insert_done()
-
-   if sysbench.opt.create_secondary then
-      print(string.format("Creating a secondary index on 'sbtest%d'...",
-                          table_num))
-      con:query(string.format("CREATE INDEX k_%d ON sbtest%d(k)",
-                              table_num, table_num))
-   end
 end
 
 local t = sysbench.sql.type


### PR DESCRIPTION
When creating a secondary index, the database needs to supplement the index for each existing data synchronously. In some distributed databases, creating a secondary index requires a lot of steps (for example, using the online schema change scheme of Google F1), and it takes longer to create a secondary index in this scenario. Create indexes before performing bulk insert, which can avoid some unnecessary work and significantly reduce the delay in the oltp prepare phase.