### PR TITLE
Fixes for sb_rand and sb_memory and supported parameters extension for memory test

### DIFF
--- a/src/sb_rand.c
+++ b/src/sb_rand.c
@@ -84,17 +84,12 @@ static rand_dist_t rand_type;
 /* pointer to the default PRNG as defined by --rand-type */
 static uint32_t (*rand_func)(uint32_t, uint32_t);
 static unsigned int rand_iter;
-static unsigned int rand_pct;
-static unsigned int rand_res;
 
 /*
   Pre-computed FP constants to avoid unnecessary conversions and divisions at
   runtime.
 */
 static double rand_iter_mult;
-static double rand_pct_mult;
-static double rand_pct_2_mult;
-static double rand_res_mult;
 
 /* parameters for Pareto distribution */
 static double pareto_h; /* parameter h */
@@ -165,15 +160,8 @@ int sb_rand_init(void)
     return 1;
   }
 
-  rand_iter = sb_get_value_int("rand-spec-iter");
+  rand_iter = 12;
   rand_iter_mult = 1.0 / rand_iter;
-
-  rand_pct = sb_get_value_int("rand-spec-pct");
-  rand_pct_mult = rand_pct / 100.0;
-  rand_pct_2_mult = rand_pct / 200.0;
-
-  rand_res = sb_get_value_int("rand-spec-res");
-  rand_res_mult = 100.0 / (100.0 - rand_res);
 
   pareto_h  = sb_get_value_double("rand-pareto-h");
   pareto_power = log(pareto_h) / log(1.0-pareto_h);

--- a/src/sb_rand.h
+++ b/src/sb_rand.h
@@ -62,13 +62,13 @@ void sb_rand_done(void);
 void sb_rand_thread_init(void);
 
 /* Generator functions */
-uint32_t sb_rand_default(uint32_t, uint32_t);
-uint32_t sb_rand_uniform(uint32_t, uint32_t);
-uint32_t sb_rand_gaussian(uint32_t, uint32_t);
-uint32_t sb_rand_pareto(uint32_t, uint32_t);
-uint32_t sb_rand_zipfian(uint32_t, uint32_t);
-uint32_t sb_rand_unique(void);
+uint64_t sb_rand_default(uint64_t, uint64_t);
+uint64_t sb_rand_uniform(uint64_t, uint64_t);
+uint64_t sb_rand_gaussian(uint64_t, uint64_t);
+uint64_t sb_rand_pareto(uint64_t, uint64_t);
+uint64_t sb_rand_zipfian(uint64_t, uint64_t);
+uint64_t sb_rand_unique(void);
 void sb_rand_str(const char *, char *);
-uint32_t sb_rand_varstr(char *, uint32_t, uint32_t);
+uint64_t sb_rand_varstr(char *, uint64_t, uint64_t);
 
 #endif /* SB_RAND_H */


### PR DESCRIPTION
First commit fixes critical bug in sb_rand which broke Gaussian distribution due to 'rand_iter' initialized to zero after Special distribution has got dropped.
Second commit extends supported --memory-total-size and --memory-block-size parameters values allowing total size to be smaller than block size. This allows another level of control of benchmarking to the user.
Third commit provides support of periodic statistics in memory tests which is not supported currently. It allows to periodically report throughput during memory test run. On the other hand it decreases benchmark throughput roughly by 5% depending on access type and distribution used and underlying hardware.
Fourth commit extends sb_rand to use 64-bits variables and functions parameters which allows to use --memory-block-size values larger than 16GB.