### PR TITLE
Add feature read data from file and secondary_ranges

### DIFF
--- a/src/db_driver.c
+++ b/src/db_driver.c
@@ -40,7 +40,7 @@
 #include "sb_ck_pr.h"
 
 /* Query length limit for bulk insert queries */
-#define BULK_PACKET_SIZE (512*1024)
+#define BULK_PACKET_SIZE (5120*1024)
 
 /* How many rows to insert before COMMITs (used in bulk insert) */
 #define ROWS_BEFORE_COMMIT 1000

--- a/src/lua/internal/sysbench.rand.lua
+++ b/src/lua/internal/sysbench.rand.lua
@@ -33,6 +33,7 @@ uint32_t sb_rand_unique(void);
 void sb_rand_str(const char *, char *);
 uint32_t sb_rand_varstr(char *, uint32_t, uint32_t);
 double sb_rand_uniform_double(void);
+void sb_file_str(char *, char *);
 ]]
 
 function sysbench.rand.uniform_uint64()
@@ -81,4 +82,12 @@ end
 
 function sysbench.rand.uniform_double()
    return ffi.C.sb_rand_uniform_double()
+end
+
+buf1 = ffi.new("char[?]", 1024)
+buf2 = ffi.new("char[?]", 4194304)
+
+function sysbench.rand.filestr()
+   ffi.C.sb_file_str(buf1, buf2)
+   return ffi.string(buf1), ffi.string(buf2)
 end

--- a/src/lua/oltp_common.lua
+++ b/src/lua/oltp_common.lua
@@ -165,7 +165,6 @@ end
 function create_table(drv, con, table_num)
    local id_index_def, id_def
    local engine_def = ""
-   local extra_table_options = "ROW_FORMAT=COMPRESSED"
    local query
 
    if sysbench.opt.secondary then
@@ -206,7 +205,8 @@ function create_table(drv, con, table_num)
      pad MEDIUMTEXT,
      %s (id)
    ) %s %s ROW_FORMAT=COMPRESSED]],
-         table_num, id_def, id_index_def, engine_def, extra_table_options)
+         table_num, id_def, id_index_def, engine_def,
+         sysbench.opt.create_table_options)
    else
       query = string.format([[
    CREATE TABLE sbtest%d(
@@ -216,7 +216,8 @@ function create_table(drv, con, table_num)
      pad CHAR(60) DEFAULT '' NOT NULL,
      %s (id)
    ) %s %s]],
-         table_num, id_def, id_index_def, engine_def, extra_table_options)
+         table_num, id_def, id_index_def, engine_def,
+         sysbench.opt.create_table_options)
    end
 
    con:query(query)

--- a/src/lua/oltp_read_only.lua
+++ b/src/lua/oltp_read_only.lua
@@ -31,6 +31,7 @@ function prepare_statements()
 
    if sysbench.opt.range_selects then
       prepare_simple_ranges()
+      prepare_secondary_ranges()
       prepare_sum_ranges()
       prepare_order_ranges()
       prepare_distinct_ranges()
@@ -46,6 +47,7 @@ function event()
 
    if sysbench.opt.range_selects then
       execute_simple_ranges()
+      execute_secondary_ranges()
       execute_sum_ranges()
       execute_order_ranges()
       execute_distinct_ranges()

--- a/src/lua/oltp_read_write.lua
+++ b/src/lua/oltp_read_write.lua
@@ -31,6 +31,7 @@ function prepare_statements()
 
    if sysbench.opt.range_selects then
       prepare_simple_ranges()
+      prepare_secondary_ranges()
       prepare_sum_ranges()
       prepare_order_ranges()
       prepare_distinct_ranges()
@@ -50,6 +51,7 @@ function event()
 
    if sysbench.opt.range_selects then
       execute_simple_ranges()
+      execute_secondary_ranges()
       execute_sum_ranges()
       execute_order_ranges()
       execute_distinct_ranges()

--- a/src/sb_rand.c
+++ b/src/sb_rand.c
@@ -79,6 +79,7 @@ static sb_arg_t rand_args[] =
   SB_OPT("rand-zipfian-exp",
          "shape parameter (exponent, theta) for the Zipfian distribution",
          "0.8", DOUBLE),
+
   SB_OPT_END
 };
 

--- a/src/sb_rand.h
+++ b/src/sb_rand.h
@@ -71,4 +71,8 @@ uint32_t sb_rand_unique(void);
 void sb_rand_str(const char *, char *);
 uint32_t sb_rand_varstr(char *, uint32_t, uint32_t);
 
+int sb_file_init(void);
+void sb_file_str(char *, char *);
+void sb_file_done(void);
+
 #endif /* SB_RAND_H */

--- a/src/sysbench.c
+++ b/src/sysbench.c
@@ -119,7 +119,7 @@ sb_arg_t general_args[] =
   SB_OPT("luajit-cmd", "perform LuaJIT control command. This option is "
          "equivalent to 'luajit -j'. See LuaJIT documentation for more "
          "information", NULL, STRING),
-  SB_OPT("filename", "whether to use file as data source", "", STRING),
+  SB_OPT("filename", "use filename as data source", "", STRING),
 
   SB_OPT_END
 };
@@ -1290,6 +1290,7 @@ static int checkpoint_cmp(const void *a_ptr, const void *b_ptr)
   return (int) (a - b);
 }
 
+
 static int init(void)
 {
   option_t *opt;
@@ -1390,15 +1391,6 @@ static int init(void)
       return 1;
     }
   }
-
-  sb_globals.tx_rate = sb_get_value_int("tx-rate");
-  if (sb_globals.tx_rate > 0)
-  {
-    log_text(LOG_WARNING, "--tx-rate is deprecated, use --rate instead");
-    sb_opt_copy("rate", "tx-rate");
-  }
-  else
-    sb_globals.tx_rate = sb_get_value_int("rate");
 
   sb_globals.report_interval = sb_get_value_int("report-interval");
 

--- a/src/sysbench.h
+++ b/src/sysbench.h
@@ -208,6 +208,7 @@ typedef struct
   int             warmup_time;  /* warmup time */
   uint64_t        nevents CK_CC_CACHELINE; /* event counter */
   const char      *luajit_cmd; /* LuaJIT command */
+  const char      *filename; /*if use a text file as dataset*/
 } sb_globals_t;
 
 extern sb_globals_t sb_globals CK_CC_CACHELINE;

--- a/tests/t/script_oltp_help.t
+++ b/tests/t/script_oltp_help.t
@@ -4,7 +4,7 @@ OLTP usage information test
 
   $ sysbench $SBTEST_SCRIPTDIR/oltp_read_write.lua help
   sysbench * (glob)
-  
+
   oltp_read_write.lua options:
     --auto_inc[=on|off]           Use AUTO_INCREMENT column as Primary Key (for MySQL), or its alternatives in other DBMS. When disabled, use client-generated IDs [on]
     --create_secondary[=on|off]   Create a secondary index in addition to the PRIMARY KEY [on]
@@ -14,6 +14,7 @@ OLTP usage information test
     --index_updates=N             Number of UPDATE index queries per transaction [1]
     --mysql_storage_engine=STRING Storage engine, if MySQL is used [innodb]
     --non_index_updates=N         Number of UPDATE non-index queries per transaction [1]
+    --secondary_ranges=N          Number of secondary range SELECT queries per transaction [1]
     --order_ranges=N              Number of SELECT ORDER BY queries per transaction [1]
     --pgsql_variant=STRING        Use this PostgreSQL variant when running with the PostgreSQL driver. The only currently supported variant is 'redshift'. When enabled, create_secondary is automatically disabled, and delete_inserts is set to 0
     --point_selects=N             Number of point SELECT queries per transaction [10]
@@ -26,4 +27,4 @@ OLTP usage information test
     --sum_ranges=N                Number of SELECT SUM() queries per transaction [1]
     --table_size=N                Number of rows per table [10000]
     --tables=N                    Number of tables [1]
-  
+


### PR DESCRIPTION
This PR add two features to sysbench:
1. Read data from a file instead of generate random data by cmd option filename
   * This is to benchmark database by real world data
   * Users can provide filename as their real data
1. secondary_ranges: select table data by secondary key without covering index(force Database to fetch rows from table data)
   * This benchmark mysql MRR(Multiple Range Read)