### PR TITLE
tests: Fix failing test due to egrep

### DIFF
--- a/tests/t/opt_report_checkpoints.t
+++ b/tests/t/opt_report_checkpoints.t
@@ -7,7 +7,7 @@
   >   exit 80
   > fi
 
-  $ sysbench ${SBTEST_SCRIPTDIR}/oltp_read_write.lua --db-driver=mysql --mysql-dry-run --time=3 --events=0 --report-checkpoints=1,2 run | egrep '(Checkpoint report|SQL statistics)'
+  $ sysbench ${SBTEST_SCRIPTDIR}/oltp_read_write.lua --db-driver=mysql --mysql-dry-run --time=3 --events=0 --report-checkpoints=1,2 run | grep -E '(Checkpoint report|SQL statistics)'
   [ 1s ] Checkpoint report:
   SQL statistics:
   [ 2s ] Checkpoint report:


### PR DESCRIPTION
Use `grep -E` instead of `egrep` as `egrep` now emits a warning.

```
t/opt_report_checkpoints.t: failed
--- t/opt_report_checkpoints.t
+++ t/opt_report_checkpoints.t.err
@@ -8,6 +8,7 @@
   > fi

   $ sysbench ${SBTEST_SCRIPTDIR}/oltp_read_write.lua --db-driver=mysql --mysql-dry-run --time=3 --events=0 --report-checkpoints=1,2 run | egrep '(Checkpoint report|SQL statistics)'
+  egrep: warning: egrep is obsolescent; using grep -E
   [ 1s ] Checkpoint report:
   SQL statistics:
   [ 2s ] Checkpoint report:
```

```
$ echo | egrep 'abc'
egrep: warning: egrep is obsolescent; using grep -E
$ grep --version
grep (GNU grep) 3.8
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Mike Haertel and others; see
<https://git.sv.gnu.org/cgit/grep.git/tree/AUTHORS>.
```