### PR TITLE
Config file read for lua tests

### DIFF
--- a/src/sb_options.c
+++ b/src/sb_options.c
@@ -112,7 +112,7 @@ option_t *sb_find_option(const char *name)
   return find_option(&options, name);
 }
 
-static void read_config_file(const char *filename)
+int read_config_file(const char *filename)
 {
   /* read config options from file */
   FILE *fp = fopen(filename, "r");
@@ -122,6 +122,7 @@ static void read_config_file(const char *filename)
     read_config(fp, &options);
     fclose(fp);
   }
+  return 1;
 }
 
 option_t *set_option(const char *name, const char *value, sb_arg_type_t type)
@@ -175,6 +176,7 @@ option_t *set_option(const char *name, const char *value, sb_arg_type_t type)
 
       break;
     case SB_ARG_TYPE_FILE:
+      add_value(&opt->values, value);
       read_config_file(value);
       break;
     default:

--- a/src/sb_options.h
+++ b/src/sb_options.h
@@ -153,6 +153,8 @@ int remove_option(sb_list_t *, char *);
     
 sb_list_t *read_config(FILE *, sb_list_t *);
 
++int read_config_file(const char *filename);
++
 int write_config(FILE *, sb_list_t *);
 
 #endif /* OPTIONS_H */

--- a/src/sysbench.c
+++ b/src/sysbench.c
@@ -1439,6 +1439,7 @@ int main(int argc, char *argv[])
 {
   sb_test_t *test = NULL;
   int rc;
+  char * filename;
 
   sb_globals.argc = argc;
   sb_globals.argv = malloc(argc * sizeof(char *));
@@ -1522,6 +1523,12 @@ int main(int argc, char *argv[])
   /* Load and parse test-specific options */
   if (parse_test_arguments(test, argc, argv))
     return EXIT_FAILURE;
+
+  /* If a config file was used, re-read it to pickup the test-specific options */
+  if ((filename = sb_get_value_string("config-file")) != NULL) {
+    read_config_file(filename);
+  }
+
 
   if (sb_lua_loaded() && sb_lua_custom_command_defined(sb_globals.cmdname))
   {


### PR DESCRIPTION
Reread config file after loading lua options to pickup test-specific settings, if they exist

This fixes the issue I had, and someone else noticed (https://github.com/akopytov/sysbench/issues/498)

Not sure this is the best way, but it does seem to work for me.