### PR TITLE
Fix race condition during fileio random request creation

### DIFF
--- a/src/tests/fileio/sb_fileio.c
+++ b/src/tests/fileio/sb_fileio.c
@@ -489,6 +489,7 @@ sb_event_t file_get_rnd_request(int thread_id)
   unsigned int         i;
 
   sb_req.type = SB_REQ_TYPE_FILE;
+  SB_THREAD_MUTEX_LOCK();
 
   if (test_mode == MODE_RND_RW)
   {

--- a/src/tests/fileio/sb_fileio.c
+++ b/src/tests/fileio/sb_fileio.c
@@ -477,7 +477,7 @@ sb_event_t file_get_seq_request(void)
 }
 
 
-/* Request generatior for random tests */
+/* Request generator for random tests */
 
 
 sb_event_t file_get_rnd_request(int thread_id)


### PR DESCRIPTION
This was leading to creation of requests with incorrect file ids, which
was causing fsync to fail on a bad file descriptor when the request was
handled.

fixes #400, fixes #430, fixes #431