### PR TITLE
Close and reinitialize Mysql handle before reconnection

### DIFF
--- a/src/drivers/mysql/drv_mysql.c
+++ b/src/drivers/mysql/drv_mysql.c
@@ -767,6 +767,7 @@ static int mysql_drv_reconnect(db_conn_t *sb_con)
 
   DEBUG("mysql_close(%p)", con);
   mysql_close(con);
+  mysql_init(con);
 
   while (mysql_drv_real_connect(db_mysql_con))
   {
@@ -774,6 +775,8 @@ static int mysql_drv_reconnect(db_conn_t *sb_con)
       return DB_ERROR_FATAL;
 
     usleep(1000);
+    mysql_close(con);
+    mysql_init(con);
   }
 
   log_text(LOG_DEBUG, "Reconnected");


### PR DESCRIPTION
We can not reuse a MYSQL handle without re-initialization after `mysql_close()`. We should close and reinitialize the handle before reconnection.

-  https://dev.mysql.com/doc/c-api/5.7/en/mysql-close.html
-  https://mariadb.com/kb/en/mysql_real_connect/

Fix #527 