### PR TITLE
fix:change docker entrypoint to exec form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN make install
 WORKDIR /root
 RUN rm -rf sysbench
 
-ENTRYPOINT sysbench
+ENTRYPOINT ["sysbench"]


### PR DESCRIPTION
### Summary
Change the `ENTRYPOINT` in the Dockerfile to use the exec form, enabling parameter passing to `docker run`.

### Example Usage
```bash
docker run -it --rm sysbench --help
```
or
```bash
docker run -it --rm sysbench cpu run
```

### Reference
For more details, see the [Dockerfile documentation on Shell and exec form](https://docs.docker.com/reference/dockerfile/#shell-and-exec-form).